### PR TITLE
Set a really unique unique_id

### DIFF
--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -135,7 +135,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
-        await self.async_set_unique_id("unique_id")
+        await self.async_set_unique_id(
+            "{username}@{school}"
+                .format(**user_input)
+                .lower()
+                .replace(" ", "-"))
         self._abort_if_unique_id_configured()
 
         errors = {}


### PR DESCRIPTION
I stumbled upon an issue that didn't allow me to register my two kids' Untis accounts.
Looks like the unique_id wasn't very unique.

Please have a look, PR should be trivial.