### PR TITLE
add Room as Location in Calendarevent

### DIFF
--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -388,7 +388,7 @@ class WebUntis:
                         CalendarEvent(
                             start=lesson.start.astimezone(),
                             end=lesson.end.astimezone(),
-                            summary=lesson.subjects[0].name,  #summary=lesson.subjects[0].long_name,
+                            summary=lesson.subjects[0].long_name,
                             location=lesson.rooms[0].long_name, #add Room as location
                             description=self.get_lesson_json(lesson),
                         )
@@ -426,7 +426,7 @@ class WebUntis:
             pass
         try:
             dic["subjects"] = [
-                {"name": str(subject.name), "long_name": str(subject.name)} #"long_name": str(subject.long_name)
+                {"name": str(subject.name), "long_name": str(subject.long_name)}
                 for subject in lesson.subjects
             ]
         except:

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -389,6 +389,7 @@ class WebUntis:
                             start=lesson.start.astimezone(),
                             end=lesson.end.astimezone(),
                             summary=lesson.subjects[0].name,  #summary=lesson.subjects[0].long_name,
+                            location=lesson.rooms[0].long_name, #add Room as location
                             description=self.get_lesson_json(lesson),
                         )
                     )

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -388,7 +388,7 @@ class WebUntis:
                         CalendarEvent(
                             start=lesson.start.astimezone(),
                             end=lesson.end.astimezone(),
-                            summary=lesson.subjects[0].long_name,
+                            summary=lesson.subjects[0].name,  #summary=lesson.subjects[0].long_name,
                             description=self.get_lesson_json(lesson),
                         )
                     )
@@ -425,7 +425,7 @@ class WebUntis:
             pass
         try:
             dic["subjects"] = [
-                {"name": str(subject.name), "long_name": str(subject.long_name)}
+                {"name": str(subject.name), "long_name": str(subject.name)} #"long_name": str(subject.long_name)
                 for subject in lesson.subjects
             ]
         except:


### PR DESCRIPTION
This line adds the Room as location in the event. Helpful to display the room in calendar, atomic revive etc. 