### PR TITLE
Make lessons without subjects available

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The format for the student's full name must be <"first name"> <"middle name">, <
 | filter_mode | The mode of the filter, e.g., `Blacklist`. |
 | filter_subjects | Subjects excluded from any data. |
 | filter_description | Exclude all lessons with specific text in the lesson info. |
+| invalid_subjects | use lessons with invalid subjects. |
 
 ### Calendar
 | Option | Description | Default |

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -334,6 +334,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ): selector.TextSelector(
                         selector.TextSelectorConfig(multiline=True)
                     ),
+                    vol.Required(
+                        "invalid_subjects",
+                        default=self.config_entry.options.get(
+                            "invalid_subjects"
+                        ),
+                    ): selector.BooleanSelector(),
                 }
             ),
         )

--- a/custom_components/webuntis/const.py
+++ b/custom_components/webuntis/const.py
@@ -18,6 +18,7 @@ DEFAULT_OPTIONS = {
     "calendar_room": "Room long name",
     "calendar_show_room_change": False,
     "notify_config": {},
+    "invalid_subjects": False,
 }
 
 NOTIFY_OPTIONS = ["cancelled", "rooms", "lesson_change", "teachers", "code"]

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -54,7 +54,8 @@
         "data": {
           "filter_mode": "Fächer Filter",
           "filter_subjects": "Fächer Filter - Fächer",
-          "filter_description": "Fächer Filter- Beschreibung"
+          "filter_description": "Fächer Filter- Beschreibung",
+          "invalid_subjects": "Fehlerhafte Fächer benutzen"
         },
         "data_description": {
           "filter_description": "Verstecke Stunden, die die folgenden Ausdrücke in der Beschreibung enthalten. (Kommagetrennte Liste)"

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -54,7 +54,8 @@
         "data": {
           "filter_mode": "Filter mode",
           "filter_subjects": "Filter mode - subjects",
-          "filter_description": "Filter mode - Description"
+          "filter_description": "Filter mode - Description",
+          "invalid_subjects": "Use invalid subjects"
         },
         "data_description": {
           "filter_description": "Hide lessons that contain the following phrases in the description. (Comma-separated list)"


### PR DESCRIPTION
Fixes: #129 

### Motivation:
Some lessons in my time table don't have a valid subject. The underlying webuntis library throws an error when accessing the `subjects` of a lesson. I wanted to introduce a setting that controls if these lessons should be ignored or not.

### Changes
- add new filter setting to 'use invalid subjects'
- check setting in `check_lesson` method when error is thrown
- add calendar event for invalid lessons 