### PR TITLE
Fix event entity callback registration for WebUntis to make event entites working properly again

### DIFF
--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -36,6 +36,8 @@ from .const import (
     DOMAIN,
     SCAN_INTERVAL,
     SIGNAL_NAME_PREFIX,
+    NAME_EVENT_LESSON_CHANGE,
+    NAME_EVENT_HOMEWORK
 )
 from .notify import *
 from .services import async_setup_services
@@ -254,9 +256,9 @@ class WebUntis:
 
     def event_entity_listen(self, callback, id) -> None:
         """Listen for lesson change events."""
-        if id == "lesson_change_event":
+        if id == NAME_EVENT_LESSON_CHANGE:
             self.lesson_change_callback = callback
-        elif id == "homework_event":
+        elif id == NAME_EVENT_HOMEWORK:
             self.homework_change_callback = callback
 
     def start_periodic_update(self) -> None:

--- a/custom_components/webuntis/const.py
+++ b/custom_components/webuntis/const.py
@@ -42,7 +42,7 @@ NAME_SENSOR_TODAY_END = "today_school_end"
 NAME_CALENDAR = "calendar"
 NAME_CALENDAR_HOMEWORK = "homework"
 NAME_CALENDAR_EXAM = "exam"
-NAME_EVENT_LESSNON_CHANGE = "lesson_change"
+NAME_EVENT_LESSON_CHANGE = "lesson_change"
 NAME_EVENT_HOMEWORK = "new_homework"
 
 

--- a/custom_components/webuntis/event.py
+++ b/custom_components/webuntis/event.py
@@ -9,7 +9,7 @@ from . import WebUntisEntity
 from .const import (
     DOMAIN,
     ICON_EVENT_LESSNON_CHANGE,
-    NAME_EVENT_LESSNON_CHANGE,
+    NAME_EVENT_LESSON_CHANGE,
     ICON_EVENT_HOMEWORK,
     NAME_EVENT_HOMEWORK,
 )
@@ -69,7 +69,7 @@ class LessonChangeEventEntity(BaseUntisEventEntity):
     def __init__(self, server) -> None:
         super().__init__(
             server=server,
-            name=NAME_EVENT_LESSNON_CHANGE,
+            name=NAME_EVENT_LESSON_CHANGE,
             icon=ICON_EVENT_LESSNON_CHANGE,
             event_types=["lesson_change", "rooms", "teachers", "cancelled", "code"],
         )


### PR DESCRIPTION
Hey,
in this PR I fixed some event entity issues, that were (probably) introduced in this commit f7edc36.
Currently the event entites are not working (they do not shown any events). For example in #220 

My changes:
- Fixed typo in constant name (LESSNON → LESSON)
- Unified usage of NAME_EVENT_LESSON_CHANGE and NAME_EVENT_HOMEWORK constants (previously a mix of hardcoded strings and constants caused mismatches).

I look forward to receiving a quick response and a merge soon (I would like to be able to use the event entity again myself 😁)