### PR TITLE
fix: compare_list teachers

### DIFF
--- a/custom_components/webuntis/notify.py
+++ b/custom_components/webuntis/notify.py
@@ -62,6 +62,9 @@ def compare_list(old_list, new_list, blacklist=[]):
                     and old_item["teachers"]
                     and new_item["teachers"] != old_item["teachers"]
                     and new_item["code"] != "cancelled"
+                    or "teachers" not in new_item
+                    and "teachers" in old_item
+                    and new_item["code"] != "cancelled"
                 ):
                     updated_items.append(["teachers", new_item, old_item])
 

--- a/custom_components/webuntis/notify.py
+++ b/custom_components/webuntis/notify.py
@@ -64,6 +64,7 @@ def compare_list(old_list, new_list, blacklist=[]):
                     and new_item["code"] != "cancelled"
                     or "teachers" not in new_item
                     and "teachers" in old_item
+                    and old_item["teachers"]
                     and new_item["code"] != "cancelled"
                 ):
                     updated_items.append(["teachers", new_item, old_item])


### PR DESCRIPTION
If the teachers attribute is not existing and it was before: also notify. 
This happens when the teacher of the lessons was removed without the lesson being marked as cancelled and without a new teacher.
Fixes #244 