### PR TITLE
Fix async_notify() to support notify.send_message

### DIFF
--- a/custom_components/webuntis/utils/utils.py
+++ b/custom_components/webuntis/utils/utils.py
@@ -105,6 +105,12 @@ async def async_notify(hass, service_id, data):
     if "target" in data and not data["target"]:
         del data["target"]
 
+    if not isinstance(service_id, str) or "." not in service_id:
+        _LOGGER.warning(
+            "Invalid service_id %r; expected 'domain.service'", service_id
+        )
+        return False
+
     domain, service = service_id.split(".", 1)
 
     target_arg = None


### PR DESCRIPTION
Fixes #253 

This PR fixes the async_notify() function to support notify.send_message as a notification service.
notify.send_message needs a structure like this `data: …, target: …` while the other services needs a structure like `data: target: ..`