### PR TITLE
Teacher access right fallback solution

### DIFF
--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -381,9 +381,7 @@ class WebUntis:
             )
 
         try:
-            self.klassen = await self._hass.async_add_executor_job(
-                self.session.klassen
-            )
+            self.klassen = await self._hass.async_add_executor_job(self.session.klassen)
         except OSError as error:
             self.klassen = []
 
@@ -1092,8 +1090,8 @@ class WebUntis:
                 {"name": str(room.name), "long_name": str(room.long_name)}
                 for room in lesson.rooms
             ]
-        except Exception:
-            pass
+        except Exception as err:
+            _LOGGER.debug("Unable to populate 'rooms' for lesson %s: %s", lesson, err)
         try:
             dic["klassen"] = [
                 {"name": str(klasse.name), "long_name": str(klasse.long_name)}
@@ -1106,8 +1104,10 @@ class WebUntis:
                 {"name": str(room.name), "long_name": str(room.long_name)}
                 for room in lesson.original_rooms
             ]
-        except Exception:
-            pass
+        except Exception as err:
+            _LOGGER.debug(
+                "Unable to populate 'original_rooms' for lesson %s: %s", lesson, err
+            )
 
         if "teachers" not in self.exclude_data:
             try:
@@ -1117,19 +1117,32 @@ class WebUntis:
                 ]
             except (OSError, errors.RemoteError) as error:
                 if "no right for getTeachers()" in str(error):
+                    _LOGGER.debug(
+                        "Unable to populate 'teachers' for lesson %s: %s, excluding teachers from now on",
+                        lesson,
+                        error,
+                    )
                     self.exclude_data_run.append("teachers")
                     self.exclude_data.append("teachers")
-
-            except:
-                pass
+            except Exception as error:
+                _LOGGER.debug(
+                    "Unable to populate 'teachers' for lesson %s: %s",
+                    lesson,
+                    error,
+                )
 
             try:
                 dic["original_teachers"] = [
                     {"name": str(teacher.name), "long_name": str(teacher.long_name)}
                     for teacher in lesson.original_teachers
                 ]
-            except:
-                pass
+            except Exception as err:
+                _LOGGER.debug(
+                    "Unable to populate 'original_teachers' for lesson %s: %s",
+                    lesson,
+                    err,
+                )
+                _LOGGER.debug("Teacher map: %s", getattr(self.session, "teacher_map", None))
 
         dic["name"] = get_lesson_name(self, lesson)
 
@@ -1205,9 +1218,24 @@ class WebUntis:
                 if "no right for getTeachers()" in str(error):
                     self.exclude_data_run.append("teachers")
                     self.exclude_data.append("teachers")
+            except Exception as error:
+                _LOGGER.debug(
+                    "Unable to populate 'teachers' for lesson %s: %s",
+                    lesson,
+                    error,
+                )
 
-            except:
-                pass
+            try:
+                dic["original_teachers"] = [
+                    {"name": str(teacher.name), "long_name": str(teacher.long_name)}
+                    for teacher in lesson.original_teachers
+                ]
+            except Exception as err:
+                _LOGGER.debug(
+                    "Unable to populate 'original_teachers' for lesson %s: %s",
+                    lesson,
+                    err,
+                )
 
         return dic
 

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -1142,7 +1142,10 @@ class WebUntis:
                     lesson,
                     err,
                 )
-                _LOGGER.debug("Teacher map: %s", getattr(self.session, "teacher_map", None))
+                _LOGGER.debug(
+                    "Teacher map has %s entries",
+                    len(getattr(self.session, "teacher_map", {})),
+                )
 
         dic["name"] = get_lesson_name(self, lesson)
 

--- a/custom_components/webuntis/utils/utils.py
+++ b/custom_components/webuntis/utils/utils.py
@@ -51,6 +51,8 @@ def compact_list(item_list, list_type=None, compact_tolerance=timedelta(minutes=
                     start - end <= compact_tolerance
                     and start >= end
                     and last_item[2]["code"] == item[2]["code"]
+                    and last_item[2].get("rooms") == item[2].get("rooms")
+                    and last_item[2].get("teachers") == item[2].get("teachers")
                 ):
                     last_item[1]["end"] = item[1]["end"]
                     last_item[2]["end"] = item[2]["end"]
@@ -75,6 +77,8 @@ def compact_list(item_list, list_type=None, compact_tolerance=timedelta(minutes=
                     and start >= end
                     and last_item["lsnumber"] == item["lsnumber"]
                     and last_item["code"] == item["code"]
+                    and last_item.get("rooms") == item.get("rooms")
+                    and last_item.get("teachers") == item.get("teachers")
                 ):
                     last_item["end"] = item["end"]
 

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -1,6 +1,7 @@
 import requests
 import json
-from webuntis import errors
+from webuntis import errors, objects
+from datetime import datetime, timedelta
 from webuntis.utils import log  # pylint: disable=no-name-in-module
 from webuntis.session import Session as WebUntisSession
 
@@ -13,6 +14,7 @@ class ExtendedSession(WebUntisSession):
     """
     This class extends the original Session to include new functionality for
     fetching homeworks from the WebUntis API using a different endpoint.
+    It also includes a fallback mechanism for fetching teacher information in case the server forbids fetching teachers directly.
     """
 
     def _send_custom_request(self, endpoint, params):
@@ -37,7 +39,7 @@ class ExtendedSession(WebUntisSession):
 
         # Ensure session is logged in
         if "jsessionid" in self.config:
-            headers["Cookie"] = f'JSESSIONID={self.config["jsessionid"]}'
+            headers["Cookie"] = f"JSESSIONID={self.config['jsessionid']}"
         else:
             raise errors.NotLoggedInError("No JSESSIONID found. Please log in first.")
 
@@ -97,3 +99,211 @@ class ExtendedSession(WebUntisSession):
 
         # Send the request and return the response
         return self._send_custom_request(endpoint, params)
+
+    def _update_teacher_mapping(
+        self, start: datetime, end: datetime, element_type_num: int, element_id: int
+    ):
+        """
+        Fetches all teachers and builds a mapping of teacher ID to teacher name.
+        This mapping is used as fallback to get the short name of the teachers in case fetching teachers directly is forbidden by the server.
+        This way the functionality the Webuntis APP provides is recreated.
+
+        :param start: Start date for fetching the timetable (used to get the relevant teachers)
+        :param end: End date for fetching the timetable (used to get the relevant teachers)
+        :param element_type_num: numerical type of the element for which the timetable is fetched (e.g., teacher, class, etc.)
+        :param element_id: The ID of the element for which the timetable is fetched
+        """
+
+        params = {
+            "options": {
+                "element": {"id": str(element_id), "type": str(element_type_num)},
+                "startDate": int(start.strftime("%Y%m%d")),
+                "endDate": int(end.strftime("%Y%m%d")),
+                "teacherFields": ["id", "name"],
+            }
+        }
+
+        result = self._request(method="getTimetable", params=params)
+
+        # Build teacher ID -> name mapping
+        teacher_map = {}
+        for period in result:
+            for t in period.get("te", []):
+                if "id" in t:
+                    if "name" in t:
+                        teacher_map[t["id"]] = t["name"]
+                    else:
+                        teacher_map[t["id"]] = (
+                            f"{t['id']}"  # no name given, use id as name to prevent errors
+                        )
+                if "orgid" in t:
+                    if "orgname" in t:
+                        teacher_map[t["orgid"]] = t["orgname"]
+                    else:
+                        teacher_map[t["orgid"]] = (
+                            f"{t['orgid']}"  # no orgname given, use orgid as name to prevent errors
+                        )
+
+        if not hasattr(self, "teacher_map"):
+            self.teacher_map = teacher_map
+        else:
+            self.teacher_map.update(teacher_map)
+
+    def teachers(self, **kw_args):
+        """
+        Public method to get teacher mapping with optional caching.
+
+        :param use_cache: Whether to use cached data if available.
+
+        """
+        # override original function to add fallback mechanism in case fetching teachers is forbidden by the server
+        # in this case the teacher name that is given in the timetable is used to build a mapping of teacher id to teacher name. This is not ideal but at least gives some information about the teachers.
+        result = None
+        if not getattr(
+            self, "teachers_forbidden", False
+        ):  # only do this when we haven't already determined that fetching teachers is forbidden, otherwise we would do unnecessary requests to the server
+            try:
+                result = super().teachers(**kw_args)
+                self.teachers_forbidden = False
+            except Exception as e:
+                if (
+                    getattr(e, "code", None) == -8509
+                ):  # -8509 is the error code for "fetching teachers is forbidden"
+                    log(
+                        "debug",
+                        f"Fetching teachers failed with error: {e}. Assuming fetching teachers is forbidden and using fallback mechanism.",
+                    )
+                    self.teachers_forbidden = True
+                else:
+                    raise  # all other exceptions should be raised as they are not related to fetching teachers being forbidden
+
+        if getattr(self, "teachers_forbidden", False):
+            if not hasattr(self, "teacher_map"):
+                self._update_teacher_mapping(
+                    start=datetime.now(),
+                    end=datetime.now() + timedelta(days=1),
+                    element_type_num=self.login_result["personType"],
+                    element_id=self.login_result["personId"],
+                )
+            # apply the mapping to build a list of teachers in the same format as the original function would return it, so that the rest of the code can work with it without needing to know about the fallback mechanism
+            data = [
+                {
+                    "id": id,
+                    "name": name,
+                    "longName": name,
+                    "foreName": name,
+                    "title": "",
+                }
+                for id, name in self.teacher_map.items()
+            ]
+            result = objects.TeacherList(session=self, data=data)
+        return result
+
+    _ELEMENT_TYPE_TABLE = {
+        "klasse": 1,
+        "teacher": 2,
+        "subject": 3,
+        "room": 4,
+        "student": 5,
+    }
+
+    def _collect_teacher_ids(self, result):
+        """Collect all teacher IDs and original teacher IDs from timetable results."""
+        teidlist = []
+        for lesson in result:
+            for entry in getattr(lesson, "_data", {}).get("te", []):
+                if entry.get("id") is not None:
+                    teidlist.append(entry["id"])
+                if entry.get("orgid") is not None:
+                    teidlist.append(entry["orgid"])
+        return teidlist
+
+    def _ensure_teacher_mapping(self, result, start, end, element_type_num, element_id):
+        """Ensure teacher mapping is up-to-date if teachers are forbidden."""
+        if not hasattr(self, "teachers_forbidden"):
+            self.teachers()  # call teachers to set teachers_forbidden attribute
+        if getattr(self, "teachers_forbidden", False):
+            teidlist = self._collect_teacher_ids(result)
+            if not set(teidlist).issubset(set(getattr(self, "teacher_map", {}).keys())):
+                self._update_teacher_mapping(
+                    start=start,
+                    end=end,
+                    element_type_num=element_type_num,
+                    element_id=element_id,
+                )
+
+    # def _timetable_extended_raw(self, end, start, element_id, element_type_num):
+    def my_timetable(self, end, start):
+        result = super().my_timetable(end=end, start=start)
+        self._ensure_teacher_mapping(
+            result,
+            start=start,
+            end=end,
+            element_type_num=self.login_result["personType"],
+            element_id=self.login_result["personId"],
+        )
+        return result
+
+    def timetable_extended(self, start, end, **type_and_id):
+        """Get the timetable for a specific school class and time period.
+
+        Like timetable, but includes more info.
+        """
+        if len(type_and_id) != 1:
+            raise TypeError(
+                "You have to specify exactly one of the following parameters by "
+                "keyword: " + (", ".join(self._ELEMENT_TYPE_TABLE.keys()))
+            )
+
+        element_type, element_id = list(type_and_id.items())[0]
+        result = super().timetable_extended(start=start, end=end, **type_and_id)
+        self._ensure_teacher_mapping(
+            result,
+            start=start,
+            end=end,
+            element_type_num=self._ELEMENT_TYPE_TABLE.get(element_type),
+            element_id=element_id,
+        )
+        return result
+
+    def timetable(self, start, end, **type_and_id):
+        """Get the timetable for a specific school class and time period.
+
+        :type start: :py:class:`datetime.datetime` or  :py:class:`datetime.date` or int
+        :param start: The beginning of the time period.
+
+        :type end: :py:class:`datetime.datetime` or  :py:class:`datetime.date` or int
+        :param end: The end of the time period.
+
+        :rtype: :py:class:`webuntis.objects.PeriodList`
+
+        Furthermore you have to explicitly define a klasse, teacher, subject,
+        room or student parameter containing the id or the object of the thing
+        you want to get a timetable about::
+
+            import datetime
+            today = datetime.date.today()
+            monday = today - datetime.timedelta(days=today.weekday())
+            friday = monday + datetime.timedelta(days=4)
+
+            klasse = s.klassen().filter(id=1)[0]  # schoolclass #1
+            tt = s.timetable(klasse=klasse, start=monday, end=friday)
+
+        :raises: :exc:`ValueError`, :exc:`TypeError`
+        """
+        if len(type_and_id) != 1:
+            raise TypeError(
+                "You have to specify exactly one of the following parameters by "
+                "keyword: " + (", ".join(self._ELEMENT_TYPE_TABLE.keys()))
+            )
+
+        element_type, element_id = list(type_and_id.items())[0]
+        result = super().timetable(start=start, end=end, **type_and_id)
+        self._ensure_teacher_mapping(
+            result,
+            start=start,
+            end=end,
+            element_type_num=self._ELEMENT_TYPE_TABLE.get(element_type),
+            element_id=element_id,
+        )
+        return result

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -166,8 +166,10 @@ class ExtendedSession(WebUntisSession):
                 result = super().teachers(**kw_args)
                 self.teachers_forbidden = False
             except Exception as e:
-                if (
-                    getattr(e, "code", None) == -8509
+                if getattr(
+                    e, "code", None
+                ) == -8509 or "no right for getTeachers()" in str(
+                    e
                 ):  # -8509 is the error code for "fetching teachers is forbidden"
                     log(
                         "debug",


### PR DESCRIPTION
Extend the webuntis session with a fallback solution to read a teacher list in case the user does not have access rights to the full teacher list.
In the case of missing access rights, the teacher list is created from the info that is provided in the lessons (id and a short 'name' of the teacher). This info is then used to create an internal teacher list, that is used by the teachers() method.
Since the teacher list is only created from the latest data, it will be updated every time the user is receiving a new timetable with previously unknown teachers.



To make it work in an existing configuration, the user has to delete the 'teachers' entry from his webuntis integration configuration (Backend->Exclude from requests) after updating the integration.