### PR TITLE
Add QR code login support

### DIFF
--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -172,10 +172,12 @@ class WebUntis:
         self.server = config.data["server"]
         self.school = config.data["school"]
         self.username = config.data["username"]
-        self.password = config.data["password"]
+        self.password = config.data.get("password", "")
         self.timetable_source = config.data["timetable_source"]
         self.timetable_source_id = config.data["timetable_source_id"]
         self.title = config.title
+        self.auth_type = config.data.get("auth_type", "password")
+        self.otp_key = config.data.get("key", "")
 
         self.calendar_show_cancelled_lessons = config.options[
             "calendar_show_cancelled_lessons"
@@ -593,7 +595,10 @@ class WebUntis:
             # _LOGGER.debug("logging in")
 
             try:
-                self.session.login()
+                if self.auth_type == "qr":
+                    self.session.login_with_otp(self.otp_key)
+                else:
+                    self.session.login()
                 # _LOGGER.debug("Login successful")
                 self._loged_in = True
                 self.updating += 1

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -32,8 +32,8 @@ from .notify import get_notification_data
 from .utils.errors import *
 from .utils.utils import async_notify, is_service
 from .utils.web_untis import get_timetable_object
+from .utils.web_untis_extended import ExtendedSession
 
-# import webuntis.session
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,17 +61,45 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         user_input: dict[str, Any] | None = None,
         errors: dict[str, Any] | None = None,
     ) -> FlowResult:
+        """Handle the initial step - choose auth method."""
+        if user_input is not None:
+            if user_input["auth_method"] == "password":
+                return await self.async_step_password()
+            elif user_input["auth_method"] == "qr":
+                return await self.async_step_qr_login()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("auth_method"): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=["password", "qr"],
+                            translation_key="auth_method",
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_password(
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
+    ) -> FlowResult:
         if user_input is not None:
             errors, self._session_temp = await self.validate_login(user_input)
 
             if not errors:
                 self._user_input_temp = user_input
+                self._user_input_temp["auth_type"] = "password"
                 return await self.async_step_timetable_source()
 
         user_input = user_input or {}
 
         return self.async_show_form(
-            step_id="user",
+            step_id="password",
             data_schema=vol.Schema(
                 {
                     vol.Required("server", default=user_input.get("server", "")): str,
@@ -85,6 +113,39 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
+        )
+
+    async def async_step_qr_login(
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        if user_input is not None:
+            errors, self._session_temp = await self.validate_qr_login(
+                user_input["qr_uri"]
+            )
+
+            if not errors:
+                self._user_input_temp["auth_type"] = "qr"
+                self._user_input_temp["key"] = user_input.get("qr_key")
+                return await self.async_step_timetable_source()
+
+        return self.async_show_form(
+            step_id="qr_login",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("qr_uri", default=user_input.get("qr_uri", "")): str,
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "qr_instructions": (
+                    "1. Go to WebUntis web interface and log in\n"
+                    "2. Navigate to Profile -> Data access -> Display QR code\n"
+                    "3. Copy the QR code URI (the URL behind the QR code)\n"
+                    "4. Paste it below"
+                ),
+            },
         )
 
     async def async_step_timetable_source(
@@ -355,6 +416,56 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except Exception as exc:
             _LOGGER.error("webuntis.Session unknown error: %s", exc)
             errors["base"] = "unknown"
+
+        return errors, session
+
+    async def validate_qr_login(self, qr_uri: str) -> dict[str, Any]:
+        hass: HomeAssistant = self.hass
+        errors = {}
+
+        try:
+            parsed = ExtendedSession.parse_qr_uri(qr_uri)
+        except (ValueError, Exception) as exc:
+            _LOGGER.error("Failed to parse QR URI: %s", exc)
+            errors["qr_uri"] = "invalid_qr_uri"
+            return errors, None
+
+        server = parsed["server"]
+        school = parsed["school"]
+        username = parsed["username"]
+        key = parsed["key"]
+
+        try:
+            parsed_url = urlparse(server)
+            socket.gethostbyname(parsed_url.hostname)
+        except Exception as exc:
+            _LOGGER.error("Cannot resolve QR hostname(%s): %s", server, exc)
+            errors["qr_uri"] = "cannot_connect"
+            return errors, None
+
+        try:
+            session = ExtendedSession(
+                server=server,
+                school=school,
+                username=username,
+                password="",
+                useragent="home-assistant",
+            )
+            await hass.async_add_executor_job(session.login_with_otp, key)
+        except Exception as exc:
+            _LOGGER.error("webuntis QR login error: %s", exc)
+            errors["qr_uri"] = "qr_login_failed"
+            return errors, None
+
+        self._user_input_temp.update(
+            {
+                "server": server,
+                "school": school,
+                "username": username,
+                "key": key,
+                "password": "",
+            }
+        )
 
         return errors, session
 

--- a/custom_components/webuntis/const.py
+++ b/custom_components/webuntis/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "webuntis"
 
-CONFIG_ENTRY_VERSION = 21
+CONFIG_ENTRY_VERSION = 22
 
 DEFAULT_OPTIONS = {
     "lesson_long_name": True,

--- a/custom_components/webuntis/manifest.json
+++ b/custom_components/webuntis/manifest.json
@@ -14,6 +14,7 @@
   ],
   "quality_scale": "silver",
   "requirements": [
+    "pyotp",
     "webuntis==0.1.24"
   ],
   "version": "v0.0.0"

--- a/custom_components/webuntis/repairs.py
+++ b/custom_components/webuntis/repairs.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 
 
 from .config_flow import ConfigFlow
+from .utils.web_untis_extended import ExtendedSession
 
 
 class IssueChangePassword(RepairsFlow):
@@ -26,6 +27,8 @@ class IssueChangePassword(RepairsFlow):
     ) -> data_entry_flow.FlowResult:
         """Handle the first step of a fix flow."""
 
+        if self._config.get("auth_type") == "qr":
+            return await self.async_step_confirm_qr()
         return await self.async_step_confirm()
 
     async def async_step_confirm(
@@ -52,6 +55,46 @@ class IssueChangePassword(RepairsFlow):
             data_schema=vol.Schema(
                 {
                     vol.Required("password"): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_confirm_qr(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle QR login credential fix - re-enter QR URI."""
+        errors = {}
+        if user_input is not None:
+            data = self._config
+            try:
+                parsed = ExtendedSession.parse_qr_uri(user_input["qr_uri"])
+                data["server"] = parsed["server"]
+                data["school"] = parsed["school"]
+                data["username"] = parsed["username"]
+                data["key"] = parsed["key"]
+                data["password"] = ""
+
+                flow = ConfigFlow()
+                flow.hass = self._hass
+                errors, _session_temp = await flow.validate_qr_login(
+                    user_input["qr_uri"]
+                )
+
+                if not errors:
+                    entry = self.hass.config_entries.async_get_entry(self._entry_id)
+                    self.hass.config_entries.async_update_entry(entry, data=data)
+                    return self.async_create_entry(title="", data={})
+
+                errors["base"] = next(iter(errors.values()))
+            except Exception as exc:
+                errors["base"] = "qr_login_failed"
+
+        return self.async_show_form(
+            step_id="confirm_qr",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("qr_uri"): str,
                 }
             ),
             errors=errors,

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -15,10 +15,19 @@
       "no_rights_for_timetable": "Keine Rechte für den Stundenplan. Wählen Sie einen anderen Namen oder eine andere Quelle.",
       "no_school_year": "Konfiguration über die Klasse nur während eines aktiven Schuljahres möglich.",
       "no_personal_timetable": "Für diesen Benutzer ist kein persönlicher Stundenplan verfügbar. Bitte wähle eine andere Quelle.",
-      "unknown": "Unerwarteter Fehler. Logs für weitere Informationen ansehen."
+      "unknown": "Unerwarteter Fehler. Logs für weitere Informationen ansehen.",
+      "invalid_qr_uri": "Ungültige QR-Code-URI. Bitte überprüfen und erneut versuchen.",
+      "qr_login_failed": "QR-Login fehlgeschlagen. Der QR-Code ist möglicherweise abgelaufen. Erzeugen Sie einen neuen."
     },
     "step": {
       "user": {
+        "description": "Wählen Sie, wie Sie sich bei WebUntis authentifizieren möchten.",
+        "data": {
+          "auth_method": "Authentifizierungsmethode"
+        }
+      },
+      "password": {
+        "description": "Geben Sie Ihre WebUntis-Serverdaten und Zugangsdaten ein.",
         "data": {
           "server": "Server",
           "school": "Schule",
@@ -29,6 +38,12 @@
         },
         "data_description": {
           "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein"
+        }
+      },
+      "qr_login": {
+        "description": "Geben Sie die QR-Code-URI aus der WebUntis-Weboberfläche ein.\n\nSo erhalten Sie den QR-Code:\n1. Melden Sie sich bei der WebUntis-Weboberfläche an\n2. Gehen Sie zu Profil (oben rechts) \u2192 Datenzugriff \u2192 QR-Code anzeigen\n3. Kopieren Sie die QR-Code-URI (Rechtsklick auf den QR-Code \u2192 Link kopieren)\n4. Fügen Sie ihn unten ein",
+        "data": {
+          "qr_uri": "QR-Code-URI"
         }
       },
       "timetable_source": {
@@ -207,6 +222,12 @@
         "class_name_short": "Klassen Name (kurz)",
         "class_name_long": "Klassen Name (lang)"
       }
+    },
+    "auth_method": {
+      "options": {
+        "password": "Passwort-Login",
+        "qr": "QR-Code-Login"
+      }
     }
   },
   "issues": {
@@ -216,7 +237,8 @@
           "cannot_connect": "Verbindung fehlgeschlagen. Überprüfe die Server-Domain.",
           "invalid_auth": "Ungültige Authentifizierung",
           "bad_credentials": "Ungültiges Passwort",
-          "unknown": "Unerwarteter Fehler"
+          "unknown": "Unerwarteter Fehler",
+          "qr_login_failed": "QR-Login fehlgeschlagen. Bitte versuchen Sie es mit einem neuen QR-Code."
         },
         "step": {
           "confirm": {
@@ -224,6 +246,13 @@
             "title": "Das Passwort wurde geändert",
             "data": {
               "password": "Passwort"
+            }
+          },
+          "confirm_qr": {
+            "description": "Bitte geben Sie die QR-Code-URI aus der WebUntis-Weboberfläche erneut ein.",
+            "title": "QR-Login-Zugangsdaten haben sich geändert",
+            "data": {
+              "qr_uri": "QR-Code-URI"
             }
           }
         }

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -15,10 +15,19 @@
       "no_rights_for_timetable": "No rights for timetable. Choose another name or source.",
       "no_school_year": "Configuration via class only possible during an active school year.",
       "no_personal_timetable": "No personal timetable is available for this user. Please choose another source.",
-      "unknown": "Unexpected error. View logs for more information."
+      "unknown": "Unexpected error. View logs for more information.",
+      "invalid_qr_uri": "Invalid QR code URI. Please check and try again.",
+      "qr_login_failed": "QR login failed. The QR code may have expired. Generate a new one."
     },
     "step": {
       "user": {
+        "description": "Choose how you want to authenticate with WebUntis.",
+        "data": {
+          "auth_method": "Authentication method"
+        }
+      },
+      "password": {
+        "description": "Enter your WebUntis server details and credentials.",
         "data": {
           "server": "Server",
           "school": "School",
@@ -29,6 +38,12 @@
         },
         "data_description": {
           "timetable_source_id": "Enter the full name of the student/teacher or the class name"
+        }
+      },
+      "qr_login": {
+        "description": "Enter the QR code URI from the WebUntis web interface.\n\nTo get the QR code:\n1. Log in to the WebUntis web interface\n2. Go to Profile (top right) \u2192 Data access \u2192 Display QR code\n3. Copy the QR code URI (right-click the QR code \u2192 Copy link)\n4. Paste it below",
+        "data": {
+          "qr_uri": "QR Code URI"
         }
       },
       "timetable_source": {
@@ -124,7 +139,7 @@
           "calendar_description": "Determine what should be in the description of a calendar event.",
           "calendar_room": "Specify what to display for location.",
           "calendar_show_room_change": "Show room changes in the calendar.",
-          "calendar_replace_name": "e.g.,\nCancelled: ❌"
+          "calendar_replace_name": "e.g.,\nCancelled: \u274c"
         }
       },
       "backend": {
@@ -208,6 +223,12 @@
         "class_name_short": "Class Name (short)",
         "class_name_long": "Class Name (long)"
       }
+    },
+    "auth_method": {
+      "options": {
+        "password": "Password Login",
+        "qr": "QR Code Login"
+      }
     }
   },
   "issues": {
@@ -217,7 +238,8 @@
           "cannot_connect": "Failed to connect. Please check the host.",
           "invalid_auth": "Invalid authentication",
           "bad_credentials": "Invalid password",
-          "unknown": "Unexpected error"
+          "unknown": "Unexpected error",
+          "qr_login_failed": "QR login failed. Please try again with a new QR code."
         },
         "step": {
           "confirm": {
@@ -225,6 +247,13 @@
             "title": "Password has been changed",
             "data": {
               "password": "Password"
+            }
+          },
+          "confirm_qr": {
+            "description": "Please re-enter the QR code URI from the WebUntis web interface.",
+            "title": "QR Login credentials have changed",
+            "data": {
+              "qr_uri": "QR Code URI"
             }
           }
         }

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -14,10 +14,19 @@
       "class_not_found": "Klasse niet gevonden. Controleer de klasse of kies een andere bron.",
       "no_rights_for_timetable": "No rights for timetable. Choose another name or source.",
       "no_school_year": "You can only configurate via Class if there is a active schoolyear.",
-      "unknown": "Unexpected error. View Logs for more infos."
+      "unknown": "Unexpected error. View Logs for more infos.",
+      "invalid_qr_uri": "Ongeldige QR-code-URI. Controleer en probeer opnieuw.",
+      "qr_login_failed": "QR-login mislukt. De QR-code is mogelijk verlopen. Genereer een nieuwe."
     },
     "step": {
       "user": {
+        "description": "Kies hoe u wilt authenticeren bij WebUntis.",
+        "data": {
+          "auth_method": "Authenticatiemethode"
+        }
+      },
+      "password": {
+        "description": "Voer uw WebUntis-servergegevens en inloggegevens in.",
         "data": {
           "server": "Server",
           "school": "School",
@@ -28,6 +37,12 @@
         },
         "data_description": {
           "timetable_source_id": "Enter the full name of the student/teacher or the class name"
+        }
+      },
+      "qr_login": {
+        "description": "Voer de QR-code-URI in van de WebUntis webinterface.\n\nOm de QR-code te krijgen:\n1. Log in op de WebUntis webinterface\n2. Ga naar Profiel (rechtsboven) \u2192 Gegevenstoegang \u2192 QR-code weergeven\n3. Kopieer de QR-code-URI (rechtsklik op de QR-code \u2192 Link kopi\u00ebren)\n4. Plak deze hieronder",
+        "data": {
+          "qr_uri": "QR-Code-URI"
         }
       },
       "timetable_source": {
@@ -189,6 +204,12 @@
         "message": "Message",
         "discord": "Discord"
       }
+    },
+    "auth_method": {
+      "options": {
+        "password": "Wachtwoord Login",
+        "qr": "QR-Code Login"
+      }
     }
   },
   "issues": {
@@ -198,7 +219,8 @@
           "cannot_connect": "Failed to connect. Please check the host.",
           "invalid_auth": "Invalid authentication",
           "bad_credentials": "Invalid password",
-          "unknown": "Unexpected error"
+          "unknown": "Unexpected error",
+          "qr_login_failed": "QR-login mislukt. Probeer opnieuw met een nieuwe QR-code."
         },
         "step": {
           "confirm": {
@@ -206,6 +228,13 @@
             "title": "Password has been changed",
             "data": {
               "password": "Password"
+            }
+          },
+          "confirm_qr": {
+            "description": "Voer de QR-code-URI opnieuw in van de WebUntis webinterface.",
+            "title": "QR-Login referenties zijn gewijzigd",
+            "data": {
+              "qr_uri": "QR-Code-URI"
             }
           }
         }

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -1,10 +1,13 @@
 import requests
 import json
+from urllib.parse import urlparse, parse_qs
 from webuntis import errors
 from webuntis.utils import log  # pylint: disable=no-name-in-module
 from webuntis.session import Session as WebUntisSession
 
 import logging
+import time
+import pyotp
 
 # logging.basicConfig(level=logging.DEBUG)
 
@@ -14,6 +17,164 @@ class ExtendedSession(WebUntisSession):
     This class extends the original Session to include new functionality for
     fetching homeworks from the WebUntis API using a different endpoint.
     """
+
+    def login_with_otp(self, otp_secret):
+        """
+        Authenticate using a TOTP secret (from QR code login).
+
+        :param otp_secret: The TOTP secret key extracted from the QR code
+        :returns: The session (for chaining)
+        """
+        try:
+            username = self.config["username"]
+            school = self.config["school"]
+            useragent = self.config["useragent"]
+        except KeyError as e:
+            raise errors.BadCredentialsError("Missing config: " + str(e))
+
+        server_url = self.config["server"]
+        base_url = server_url.rstrip("/")
+
+        token = pyotp.TOTP(otp_secret).now()
+        client_time = int(time.time() * 1000)
+
+        response = requests.post(
+            f"{base_url}/WebUntis/jsonrpc_intern.do",
+            params={
+                "m": "getUserData2017",
+                "school": school,
+                "v": "i2.2",
+            },
+            data=json.dumps({
+                "id": useragent,
+                "method": "getUserData2017",
+                "params": [
+                    {
+                        "auth": {
+                            "clientTime": client_time,
+                            "user": username,
+                            "otp": int(token),
+                        },
+                    },
+                ],
+                "jsonrpc": "2.0",
+            }),
+            headers={
+                "User-Agent": useragent,
+                "Content-Type": "application/json",
+            },
+        )
+
+        if response.status_code != 200:
+            raise errors.AuthError(
+                f"OTP login failed with status {response.status_code}"
+            )
+
+        response_data = response.json()
+        if response_data.get("error"):
+            raise errors.BadCredentialsError(
+                response_data["error"].get("message", "OTP login failed")
+            )
+
+        cookies = response.headers.get("set-cookie", "")
+        jsessionid = self._extract_jsessionid(cookies)
+
+        if not jsessionid:
+            raise errors.AuthError("No JSESSIONID received from OTP login")
+
+        self.config["jsessionid"] = jsessionid
+        log("debug", "Did get a jsessionid from OTP login: " + jsessionid)
+
+        self.login_result = dict()
+        self._fetch_person_info(base_url)
+
+        return self
+
+    @staticmethod
+    def _extract_jsessionid(set_cookie_header):
+        """Extract JSESSIONID from Set-Cookie header."""
+        if not set_cookie_header:
+            return None
+        for cookie_part in set_cookie_header.split(";"):
+            cookie_part = cookie_part.strip()
+            if "=" in cookie_part:
+                key, value = cookie_part.split("=", 1)
+                if key.strip().upper() == "JSESSIONID":
+                    return value.strip()
+        return None
+
+    def _fetch_person_info(self, base_url):
+        """Fetch personId and personType from app config after OTP login."""
+        headers = {
+            "User-Agent": self.config["useragent"],
+            "Cookie": f'JSESSIONID={self.config["jsessionid"]}',
+        }
+
+        config_resp = requests.get(
+            f"{base_url}/WebUntis/api/app/config",
+            headers=headers,
+        )
+        config_data = config_resp.json().get("data", {})
+        login_config = config_data.get("loginServiceConfig", {})
+        user_config = login_config.get("user", {})
+
+        person_id = user_config.get("personId")
+        if person_id is not None:
+            self.login_result["personId"] = person_id
+
+        person_type = None
+        persons = user_config.get("persons", [])
+        for person in persons:
+            if person.get("id") == person_id:
+                person_type = person.get("type")
+                break
+        if person_type is not None:
+            self.login_result["personType"] = person_type
+
+        try:
+            day_config_resp = requests.get(
+                f"{base_url}/WebUntis/api/daytimetable/config",
+                headers=headers,
+            )
+            day_data = day_config_resp.json().get("data", {})
+            klasse_id = day_data.get("klasseId")
+            if klasse_id is not None:
+                self.login_result["klasseId"] = klasse_id
+        except Exception:
+            pass
+
+    @staticmethod
+    def parse_qr_uri(qr_uri):
+        """
+        Parse a WebUntis QR code URI and extract connection parameters.
+
+        QR URIs look like:
+        untis://setschool?url=...&school=...&user=...&key=...&schoolNumber=...
+
+        :param qr_uri: The raw QR code URI string
+        :returns: dict with server, school, username, key
+        """
+        parsed = urlparse(qr_uri)
+        params = parse_qs(parsed.query)
+
+        result = {}
+        for key in ("url", "school", "user", "key"):
+            value = params.get(key, [None])[0]
+            if value is None:
+                raise ValueError(f"Missing required parameter '{key}' in QR URI")
+            result[key] = value
+
+        server = result["url"]
+        if not server.lower().startswith(("http://", "https://")):
+            server = "https://" + server
+        result["url"] = server
+
+        return {
+            "server": result["url"],
+            "school": result["school"],
+            "username": result["user"],
+            "key": result["key"],
+        }
 
     def _send_custom_request(self, endpoint, params):
         """

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -38,32 +38,36 @@ class ExtendedSession(WebUntisSession):
         token = pyotp.TOTP(otp_secret).now()
         client_time = int(time.time() * 1000)
 
-        response = requests.post(
-            f"{base_url}/WebUntis/jsonrpc_intern.do",
-            params={
-                "m": "getUserData2017",
-                "school": school,
-                "v": "i2.2",
-            },
-            data=json.dumps({
-                "id": useragent,
-                "method": "getUserData2017",
-                "params": [
-                    {
-                        "auth": {
-                            "clientTime": client_time,
-                            "user": username,
-                            "otp": int(token),
+        try:
+            response = requests.post(
+                f"{base_url}/WebUntis/jsonrpc_intern.do",
+                params={
+                    "m": "getUserData2017",
+                    "school": school,
+                    "v": "i2.2",
+                },
+                data=json.dumps({
+                    "id": useragent,
+                    "method": "getUserData2017",
+                    "params": [
+                        {
+                            "auth": {
+                                "clientTime": client_time,
+                                "user": username,
+                                "otp": int(token),
+                            },
                         },
-                    },
-                ],
-                "jsonrpc": "2.0",
-            }),
-            headers={
-                "User-Agent": useragent,
-                "Content-Type": "application/json",
-            },
-        )
+                    ],
+                    "jsonrpc": "2.0",
+                }),
+                headers={
+                    "User-Agent": useragent,
+                    "Content-Type": "application/json",
+                },
+                timeout=10,
+            )
+        except requests.RequestException as err:
+            raise errors.AuthError(f"OTP login request failed: {err}") from err
 
         if response.status_code != 200:
             raise errors.AuthError(


### PR DESCRIPTION
## Summary

Adds support for WebUntis QR code login, allowing users to authenticate using the QR code from the WebUntis web interface instead of a username/password.

## How it works

1. User goes to WebUntis web interface → Profile → Data access → Display QR code
2. Copies the QR code URI (contains server, school, username, and TOTP key)
3. Pastes into the Home Assistant config flow
4. On each login, a time-based OTP is generated from the key and sent to the `jsonrpc_intern.do` endpoint

## Changes

- **manifest.json**: Added `pyotp` dependency for TOTP generation
- **config_flow.py**: New auth method selector (Password / QR Code), QR login step with URI input and validation
- **web_untis_extended.py**: Added `login_with_otp()`, `parse_qr_uri()`, `_extract_jsessionid()`, `_fetch_person_info()`
- **__init__.py**: Detects auth type and routes to OTP or password login
- **repairs.py**: Added QR-specific credential repair flow
- **const.py**: Bumped config entry version to 22
- **translations**: English, German, Dutch strings for QR login

## Tested

Successfully tested against a live WebUntis server — QR URI parsing, TOTP generation, OTP auth, person info fetch, and schoolyears fetch all work correctly.