### PR TITLE
Add reconfigure flow

### DIFF
--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -47,6 +47,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     _session_temp = None
     _user_input_temp = {}
     _source_id = None
+    _reconfigure = False
 
     @staticmethod
     @callback
@@ -55,6 +56,35 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.OptionsFlow:
         """Create the options flow."""
         return OptionsFlowHandler(config_entry)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult | FlowResult:
+        """Handle reconfiguration of an existing entry."""
+        self._reconfigure = True
+        # During reconfigure only allow changing password and timetable source (otherwise the entity id is deprecated)
+        entry = self._get_reconfigure_entry()
+        current = entry.data if entry else {}
+
+        if user_input:
+            # Merge submitted fields with existing fixed fields so validate_login has server, school and username
+            merged = {**current, **user_input}
+            errors, self._session_temp = await self.validate_login(merged)
+
+            if not errors:
+                merged["school"] = current.get("school")
+                merged["username"] = current.get("username")
+                self._user_input_temp = merged
+                return await self.async_step_timetable_source()
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    "password": str,
+                }
+            ),
+        )
 
     async def async_step_user(
         self,
@@ -266,6 +296,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             f"{self._source_id}@{user_input['school']}".lower().replace(" ", "-")
         )
         self._abort_if_unique_id_configured()
+        # If the flow was started as a reconfigure, update and reload the existing entry instead of creating a new one.
+        if self._reconfigure:
+            return self.async_update_reload_and_abort(
+                entry=self._get_reconfigure_entry(), data=user_input
+            )
+
         return self.async_create_entry(
             title=user_input["username"],
             data=user_input,

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -58,13 +58,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return OptionsFlowHandler(config_entry)
 
     async def async_step_reconfigure(
-        self, user_input: dict[str, Any] | None = None
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
     ) -> config_entries.ConfigFlowResult | FlowResult:
         """Handle reconfiguration of an existing entry."""
         self._reconfigure = True
         # During reconfigure only allow changing password and timetable source (otherwise the entity id is deprecated)
         entry = self._get_reconfigure_entry()
         current = entry.data if entry else {}
+        errors = errors or {}
 
         if user_input:
             # Merge submitted fields with existing fixed fields so validate_login has server, school and username
@@ -84,6 +87,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "password": str,
                 }
             ),
+            errors=errors,
         )
 
     async def async_step_user(
@@ -381,7 +385,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             await hass.async_add_executor_job(session.login)
         except webuntis.errors.BadCredentialsError:
-            errors["username"] = "bad_credentials"
+            errors["base"] = "bad_credentials"
         except requests.exceptions.ConnectionError as exc:
             _LOGGER.error("webuntis.Session connection error: %s", exc)
             errors["server"] = "cannot_connect"

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -56,6 +56,11 @@
           "klasse": "Klasse",
           "back": "Zurück"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "password": "Passwort"
+        }
       }
     }
   },

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -56,6 +56,11 @@
           "klasse": "Class",
           "back": "Back"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "password": "Password"
+        }
       }
     }
   },

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -52,6 +52,11 @@
         "data": {
           "klasse": "Class"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "password": "Wachtwoord"
+        }
       }
     }
   },


### PR DESCRIPTION
This PR adds a reconfigure flow for the config entries.
It allows to change the password or the timetable source without deleting the whole entry. It uses Home Assistants reconfigure function for config entries.

-> The username and school is fixed because it would change the entity id and unique ids.

Fixes #280 