### PR TITLE
Improve setup & config flow

### DIFF
--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -107,7 +107,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            description_placeholders={"school_help_url": "https://example.com"},
+            description_placeholders={"school_help_url": "https://github.com/JonasJoKuJonas/homeassistant-WebUntis/blob/main/docs/SETUP.md#configuration-via-ui"},
             data_schema=vol.Schema(
                 {
                     vol.Required("school", default=user_input.get("school", "")): str,

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -371,7 +371,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         hass: HomeAssistant = self.hass
 
         errors = {}
-        server = credentials["advanced_options"]["server"]
+        session = None
+        server = credentials.get("advanced_options", {}).get("server")
 
         if server:
             server = server.strip()

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
+from homeassistant.data_entry_flow import section as data_entry_flow_section
 from homeassistant.helpers import selector
 
 from .const import (
@@ -94,7 +95,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self,
         user_input: dict[str, Any] | None = None,
         errors: dict[str, Any] | None = None,
-    ) -> FlowResult:
+    ) -> FlowResult | config_entries.ConfigFlowResult:
         if user_input is not None:
             errors, self._session_temp = await self.validate_login(user_input)
 
@@ -108,7 +109,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required("server", default=user_input.get("server", "")): str,
                     vol.Required("school", default=user_input.get("school", "")): str,
                     vol.Required(
                         "username", default=user_input.get("username", "")
@@ -116,6 +116,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(
                         "password", default=user_input.get("password", "")
                     ): str,
+                    vol.Required("advanced_options"): data_entry_flow_section(
+                        vol.Schema(
+                            {
+                                vol.Optional(
+                                    "server", default=user_input.get("server", "")
+                                ): str,
+                            }
+                        ),
+                        {"collapsed": True},
+                    ),
                 }
             ),
             errors=errors,
@@ -354,25 +364,41 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def validate_login(self, credentials: dict[str, Any]) -> dict[str, Any]:
+    async def validate_login(
+        self, credentials: dict[str, Any]
+    ) -> dict[str, Any] | tuple[dict[Any, Any], Any]:
         hass: HomeAssistant = self.hass
 
         errors = {}
+        server = credentials["advanced_options"]["server"]
 
-        server = credentials["server"].strip()
+        if server:
+            server = server.strip()
+            if not server.lower().startswith(("http://", "https://")):
+                server = "https://" + server
 
-        if not server.lower().startswith(("http://", "https://")):
-            server = "https://" + server
+            parsed = urlparse(server)
+            hostname = parsed.hostname
+            credentials["server"] = f"{parsed.scheme}://{parsed.netloc}"
+        else:
+            server = f"https://{credentials['school']}.webuntis.com"
+            credentials["server"] = server
+            parsed = urlparse(server)
+            hostname = parsed.hostname
+            _LOGGER.debug("No server provided, use URL: %s", credentials["server"])
 
-        parsed = urlparse(server)
-        hostname = parsed.hostname
-        credentials["server"] = f"{parsed.scheme}://{parsed.netloc}"
+        if hostname is None:
+            _LOGGER.error(
+                "Cannot resolve hostname(%s): invalid hostname", credentials["server"]
+            )
+            errors["base"] = "cannot_connect"
+            return errors, None
 
         try:
             socket.gethostbyname(hostname)
         except Exception as exc:
             _LOGGER.error("Cannot resolve hostname(%s): %s", credentials["server"], exc)
-            errors["server"] = "cannot_connect"
+            errors["base"] = "cannot_connect"
             return errors, None
 
         try:
@@ -388,7 +414,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "bad_credentials"
         except requests.exceptions.ConnectionError as exc:
             _LOGGER.error("webuntis.Session connection error: %s", exc)
-            errors["server"] = "cannot_connect"
+            errors["base"] = "cannot_connect"
         except webuntis.errors.RemoteError as exc:  # pylint: disable=no-member
             errors["school"] = "school_not_found"
             raise (exc)

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -107,6 +107,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
+            description_placeholders={"school_help_url": "https://example.com"},
             data_schema=vol.Schema(
                 {
                     vol.Required("school", default=user_input.get("school", "")): str,

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -417,7 +417,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "cannot_connect"
         except webuntis.errors.RemoteError as exc:  # pylint: disable=no-member
             errors["school"] = "school_not_found"
-            raise (exc)
         except Exception as exc:
             _LOGGER.error("webuntis.Session unknown error: %s", exc)
             errors["base"] = "unknown"

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -20,7 +20,6 @@
     "step": {
       "user": {
         "data": {
-          "server": "Server",
           "school": "Schule",
           "username": "Benutzername",
           "password": "Passwort",
@@ -28,7 +27,16 @@
           "timetable_source_id": "Voller Name/Klasse"
         },
         "data_description": {
-          "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein"
+          "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein",
+          "school": "Du weißt nicht, wie du den Schulnamen finden kannst? [Klick hier]() für Hilfe."
+        },
+        "sections": {
+          "advanced_options": {
+            "name": "Erweiterte Optionen (optional)",
+            "data": {
+              "server": "Server URL"
+            }
+          }
         }
       },
       "timetable_source": {

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -28,7 +28,7 @@
         },
         "data_description": {
           "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein",
-          "school": "Du weißt nicht, wie du den Schulnamen finden kannst? [Klick hier]() für Hilfe."
+          "school": "Du weißt nicht, wie du den Schulnamen finden kannst? [Klick hier]({school_help_url}) für Hilfe."
         },
         "sections": {
           "advanced_options": {

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -20,7 +20,6 @@
     "step": {
       "user": {
         "data": {
-          "server": "Server",
           "school": "School",
           "username": "Username",
           "password": "Password",
@@ -33,7 +32,10 @@
         },
         "sections": {
           "advanced_options": {
-            "name": "Advanced Options (optional)"
+            "name": "Advanced Options (optional)",
+            "data": {
+              "server": "Server URL"
+            }
           }
         }
       },

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -28,7 +28,13 @@
           "timetable_source_id": "Full name/Class"
         },
         "data_description": {
-          "timetable_source_id": "Enter the full name of the student/teacher or the class name"
+          "timetable_source_id": "Enter the full name of the student/teacher or the class name",
+          "school": "Don't know how to get the school name? [Click here](https://example.com) for instructions."
+        },
+        "sections": {
+          "advanced_options": {
+            "name": "Advanced Options (optional)"
+          }
         }
       },
       "timetable_source": {

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -28,7 +28,7 @@
         },
         "data_description": {
           "timetable_source_id": "Enter the full name of the student/teacher or the class name",
-          "school": "Don't know how to get the school name? [Click here](https://example.com) for instructions."
+          "school": "Don't know how to get the school name? [Click here]({school_help_url}) for instructions."
         },
         "sections": {
           "advanced_options": {

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -19,7 +19,6 @@
     "step": {
       "user": {
         "data": {
-          "server": "Server",
           "school": "School",
           "username": "Gebruikersnaam",
           "password": "Wachtwoord",
@@ -27,7 +26,16 @@
           "timetable_source_id": "Full name/Class"
         },
         "data_description": {
-          "timetable_source_id": "Enter the full name of the student/teacher or the class name"
+          "timetable_source_id": "Enter the full name of the student/teacher or the class name",
+          "school": "Weet je niet hoe je de schoolnaam kunt achterhalen? [Klik hier]() voor instructies."
+        },
+        "sections": {
+          "advanced_options": {
+            "name": "uitgebreide opties (optioneel)",
+            "data": {
+              "server": "Server URL"
+            }
+          }
         }
       },
       "timetable_source": {

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -27,7 +27,7 @@
         },
         "data_description": {
           "timetable_source_id": "Enter the full name of the student/teacher or the class name",
-          "school": "Weet je niet hoe je de schoolnaam kunt achterhalen? [Klik hier]() voor instructies."
+          "school": "Weet je niet hoe je de schoolnaam kunt achterhalen? [Klik hier]({school_help_url}) voor instructies."
         },
         "sections": {
           "advanced_options": {

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -38,13 +38,13 @@ TZ=Europe/Berlin
 > [!TIP]
 > ### Find school name
 >Visit https://webuntis.com and search/ open your school.
+>The URL should be something like this:
 >```
 >https://demo-school.webuntis.com/today
 >```
->then the server is `https://demo-school.webuntis.com` and the school is `demo-school`.
+>Then the schoolname is `demo-school`.
 
 
----
 
 ### Alternative way to find school and server name (not recommended)
 You can find the school field and the server field (optional - in the advanced options) in the URL:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -35,24 +35,36 @@ TZ=Europe/Berlin
 
 ## Configuration via UI
 
-### Server & School
+> [!IMPORTANT]
+> How to find the school name
 
-Visit https://webuntis.com and click on your school.
+### Find school name
 
-In the URL you should find the information you need:
+Visit https://webuntis.com and search/ open your school.
 
-```
-https://demo.webuntis.com/WebUntis/?school=Demo-School#/basic/login
-        ^^^^^^^^^^^^^^^^^                  ^^^^^^^^^^^
-              Server                          School
-```
+In the URL you should find the school name you need:
 
-If your school has the new address pattern, similar to this:
+If your school has the address pattern, similar to this:
 
 ```
 https://demo-school.webuntis.com/today
 ```
 then the server is `https://demo-school.webuntis.com` and the school is `demo-school`.
+
+
+
+---
+
+### Alternative way to find out (not recommended)
+You can find the school field and the server field (optional - in the advanced options) in the URL:
+
+```
+https://demo.webuntis.com/WebUntis/?school=Demo-School#/basic/login
+        ^^^^^^^^^^^^^^^^                   ^^^^^^^^^^^
+        Server URL                            School
+```
+
+---
 
 ### Username and Password
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -35,27 +35,18 @@ TZ=Europe/Berlin
 
 ## Configuration via UI
 
-> [!IMPORTANT]
-> How to find the school name
-
-### Find school name
-
-Visit https://webuntis.com and search/ open your school.
-
-In the URL you should find the school name you need:
-
-If your school has the address pattern, similar to this:
-
-```
-https://demo-school.webuntis.com/today
-```
-then the server is `https://demo-school.webuntis.com` and the school is `demo-school`.
-
+> [!TIP]
+> ### Find school name
+>Visit https://webuntis.com and search/ open your school.
+>```
+>https://demo-school.webuntis.com/today
+>```
+>then the server is `https://demo-school.webuntis.com` and the school is `demo-school`.
 
 
 ---
 
-### Alternative way to find out (not recommended)
+### Alternative way to find school and server name (not recommended)
 You can find the school field and the server field (optional - in the advanced options) in the URL:
 
 ```


### PR DESCRIPTION
This PR improves the setup proccess. 
Before new users often didn't know what the school and server fields mean. With this refactor the integration is much easier to setup since the users haven't to lookup in the documentation themselves. 

- Auto creating the server url only by providing the school name
- Add direct link to the docs for instructions how to find out the school name
- For edge cases where the server url is different than the school id (should be very rare), there is an optional field in the "advanced options" section


<img width="432" height="462" alt="image" src="https://github.com/user-attachments/assets/5677e9ad-0d13-40cb-96f2-ec9a7ac3bd5b" />
