### PR TITLE
Fix reconfigure and timetable_source translations

### DIFF
--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -433,7 +433,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
         session = None
-        server = credentials.get("advanced_options", {}).get("server")
+        server =  credentials.get("server") or credentials.get("advanced_options", {}).get("server") # keep fallback for advanced_options for backward compatibility
 
         if not server:
             # use server from selected school (provided by the untis search)

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -38,7 +38,9 @@
         }
       },
       "timetable_source": {
-        "description": "Wähle die Quelle"
+        "data": {
+          "timetable_source": "Wähle die Datenquelle für den Stundenplan:"
+        }
       },
       "pick_student": {
         "description": "Name eines Schülers eingeben",

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -38,7 +38,9 @@
         }
       },
       "timetable_source": {
-        "description": "Select the data source"
+        "data": {
+          "timetable_source": "Select the timetable data source:"
+        }
       },
       "pick_student": {
         "description": "Enter a Student Name",

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -37,7 +37,9 @@
         }
       },
       "timetable_source": {
-        "description": "Select the data source"
+        "data": {
+          "timetable_source": "Selecteer de bron van het rooster:"
+        }
       },
       "pick_student": {
         "description": "Enter a Student Name",


### PR DESCRIPTION
- Fix the reconfigure flow -> Check the right server field in validate_login
- Update translations. Before there always was the description + "timetable_source" instead of a translation

Fixes #280 