### PR TITLE
Bump devcontainer py version to 3.14

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "ludeeus/integration_blueprint",
-    "image": "mcr.microsoft.com/devcontainers/python:3.13",
+    "image": "mcr.microsoft.com/devcontainers/python:3.14",
     "postCreateCommand": "scripts/setup",
     "runArgs": [
         "--network=host"


### PR DESCRIPTION
Python version 3.14 is needed for the newest HA versions