### PR TITLE
Add QR Code Login as a second auth method

### DIFF
--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 # pylint: disable=maybe-no-member
 from webuntis import errors
@@ -306,6 +307,10 @@ class WebUntis:
             for i in self.exclude_data_run:
                 self.exclude_data_(i)
 
+        if getattr(self, "is_qr", False) and "jsessionid" not in self.session.config:
+            client_session = async_get_clientsession(self._hass)
+            await self.session.async_refresh_qr(self.qr_data, client_session)
+
         login_error = await self._hass.async_add_executor_job(self.webuntis_login)
 
         if login_error:
@@ -590,64 +595,38 @@ class WebUntis:
         await self._hass.async_add_executor_job(self.webuntis_logout)
 
     def webuntis_login(self):
-        if self._loged_in:
-            # Check if there is a session id.
-            if "jsessionid" not in self.session.config:
-                _LOGGER.debug("No session id found")
-                self._loged_in = False
-            else:
-                # Keep the existing session if the cookie is still present.
-                # WebUntis' schoolyear probe can emit -8998 during holiday gaps.
-                self.updating += 1
-                return None
+        """Handle login for standard password sessions."""
+        if getattr(self, "is_qr", False):
+            return None
 
-        if not self._loged_in:
-            # _LOGGER.debug("logging in")
+        if self._loged_in and "jsessionid" in self.session.config:
+            self.updating += 1
+            return None
 
-            try:
-                self.session.login()
-                # _LOGGER.debug("Login successful")
-                self._loged_in = True
-                self.updating += 1
-
-                return None
-            except OSError as error:
-                # Login error, set all properties to unknown.
-                self.next_class = None
-                self.next_class_json = None
-                self.next_lesson_to_wake_up = None
-                self.calendar_events = []
-                self.calendar_homework = []
-                self.calendar_exams = []
-                self.next_day_json = None
-                self.day_json = None
-
-                # Inform user once about failed update if necessary.
-                if not self._last_status_request_failed:
-                    _LOGGER.warning(
-                        "Login to WebUntis '%s@%s' failed - OSError: %s",
-                        self.school,
-                        self.username,
-                        error,
-                    )
-                self._last_status_request_failed = True
-
-                return error
-            except Exception as error:
-                _LOGGER.error(
-                    "Login to WebUntis '%s@%s' failed - ERROR: %s",
-                    self.school,
-                    self.username,
-                    error,
-                )
-                self._last_status_request_failed = True
-                return error
+        try:
+            self.session.login()
+            self._loged_in = True
+            self.updating += 1
+            return None
+        except Exception as error:
+            _LOGGER.error(
+                "Login failed for '%s@%s': %s", self.school, self.username, error
+            )
+            self._last_status_request_failed = True
+            return error
 
     def webuntis_logout(self):
-        self.updating -= 1
+        """Logout from WebUntis (skipped for QR sessions)."""
+        self.updating = max(0, self.updating - 1)
+
+        if getattr(self, "is_qr", False):
+            return
+
         if not self.keep_logged_in and self.updating == 0:
-            self.session.logout()
-            # _LOGGER.debug("Logout successful")
+            try:
+                self.session.logout()
+            except Exception as error:
+                _LOGGER.debug("Logout failed: %s", error)
             self._loged_in = False
 
     def get_student_id(self):

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -225,7 +225,13 @@ class WebUntis:
             session_kwargs["jsessionid"] = config.data["jsessionid"]
 
         self.session = ExtendedSession(**session_kwargs)
-        self._loged_in = False
+        if config.data.get("jsessionid"):
+            self.session.login_result = {
+                key: config.data[key]
+                for key in ("personType", "personId", "klasseId")
+                if key in config.data
+            }
+        self._loged_in = bool(config.data.get("jsessionid"))
         self._last_status_request_failed = False
         self._no_lessons = False
         self.updating = 0

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -384,10 +384,20 @@ class WebUntis:
                 return True
 
             try:
+                _LOGGER.warning(
+                    "QR session refresh START for '%s@%s'",
+                    self.school,
+                    self.username,
+                )
                 client_session = async_get_clientsession(self._hass)
                 new_session, jsessionid = await ExtendedSession.async_create_from_qr(
                     self.qr_data,
                     client_session,
+                )
+                _LOGGER.warning(
+                    "QR session refresh SUCCESS for '%s@%s'",
+                    self.school,
+                    self.username,
                 )
 
                 # Only assign after async_create_from_qr finished successfully.
@@ -395,14 +405,6 @@ class WebUntis:
                 self._loged_in = True
                 self._qr_session_created_at = datetime.now(timezone.utc)
 
-                self._hass.config_entries.async_update_entry(
-                    self._config,
-                    data={
-                        **self._config.data,
-                        "jsessionid": jsessionid,
-                        **self.session.login_result,
-                    },
-                )
                 return True
             except Exception as err:
                 _LOGGER.error("QR-Code Re-Authentication fehlgeschlagen: %s", err)

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -172,7 +172,7 @@ class WebUntis:
         self.server = config.data["server"]
         self.school = config.data["school"]
         self.username = config.data["username"]
-        self.password = config.data["password"]
+        self.password = config.data.get("password", "")
         self.timetable_source = config.data["timetable_source"]
         self.timetable_source_id = config.data["timetable_source_id"]
         self.title = config.title
@@ -213,13 +213,17 @@ class WebUntis:
             config.get("options") for config in self.notify_config.values()
         )
 
-        self.session = ExtendedSession(
-            username=self.username,
-            password=self.password,
-            server=self.server,
-            useragent="foo",
-            school=self.school,
-        )
+        session_kwargs = {
+            "username": self.username,
+            "password": self.password,
+            "server": self.server,
+            "useragent": "foo",
+            "school": self.school,
+        }
+        if config.data.get("jsessionid"):
+            session_kwargs["jsessionid"] = config.data["jsessionid"]
+
+        self.session = ExtendedSession(**session_kwargs)
         self._loged_in = False
         self._last_status_request_failed = False
         self._no_lessons = False

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -531,8 +531,7 @@ class WebUntis:
             )
             self.subjects = subjects
         except OSError as error:
-            if not self.is_qr:
-                self.subjects = []
+            self.subjects = []
 
             _LOGGER.warning(
                 "Updating the subjects of '%s@%s' failed - OSError: %s",
@@ -548,8 +547,7 @@ class WebUntis:
             )
             self.klassen = klassen
         except OSError as error:
-            if not self.is_qr:
-                self.klassen = []
+            self.klassen = []
 
             _LOGGER.warning(
                 "Updating the classes (klassen) of '%s@%s' failed - OSError: %s",
@@ -565,8 +563,7 @@ class WebUntis:
             )
             self.student_id = student_id
         except OSError as error:
-            if not self.is_qr:
-                self.student_id = None
+            self.student_id = None
 
             _LOGGER.warning(
                 "Updating the student_id of '%s@%s' failed - OSError: %s",
@@ -582,8 +579,7 @@ class WebUntis:
             )
             self.next_class = next_class
         except OSError as error:
-            if not self.is_qr:
-                self.next_class = None
+            self.next_class = None
 
             _LOGGER.warning(
                 "Updating the property next_class of '%s@%s' failed - OSError: %s",
@@ -599,8 +595,7 @@ class WebUntis:
             )
             self.next_lesson_to_wake_up = next_lesson_to_wake_up
         except OSError as error:
-            if not self.is_qr:
-                self.next_lesson_to_wake_up = None
+            self.next_lesson_to_wake_up = None
 
             _LOGGER.warning(
                 "Updating the property next_lesson_to_wake_up of '%s@%s' failed - OSError: %s",
@@ -616,8 +611,7 @@ class WebUntis:
             )
             self.next_day_json = next_day_json
         except OSError as error:
-            if not self.is_qr:
-                self.next_day_json = None
+            self.next_day_json = None
 
             _LOGGER.warning(
                 "Updating the property next_day_json of '%s@%s' failed - OSError: %s",
@@ -633,8 +627,7 @@ class WebUntis:
             )
             self.day_json = day_json
         except OSError as error:
-            if not self.is_qr:
-                self.day_json = None
+            self.day_json = None
 
             _LOGGER.warning(
                 "Updating the property day_json of '%s@%s' failed - OSError: %s",
@@ -654,8 +647,7 @@ class WebUntis:
                 timedelta(minutes=self.lesson_compacting_tolerance),
             )
         except OSError as error:
-            if not self.is_qr:
-                self.calendar_events = []
+            self.calendar_events = []
 
             _LOGGER.warning(
                 "Updating the property calendar_events of '%s@%s' failed - OSError: %s",
@@ -672,8 +664,7 @@ class WebUntis:
                 )
                 self.calendar_exams = calendar_exams
             except OSError as error:
-                if not self.is_qr:
-                    self.calendar_exams = []
+                self.calendar_exams = []
 
                 _LOGGER.warning(
                     "Updating the property calendar_exams of '%s@%s' failed - OSError: %s",
@@ -694,14 +685,13 @@ class WebUntis:
                 )
                 self.calendar_homework = calendar_homework
             except OSError as error:
-                if not self.is_qr:
-                    self.calendar_homework = []
-                    param_list = []
-                else:
-                    param_list = [
-                        {"homework_id": homework_id}
-                        for homework_id in self.calendar_homework_ids
-                    ]
+                self.calendar_homework = []
+                param_list = []
+
+                param_list = [
+                    {"homework_id": homework_id}
+                    for homework_id in self.calendar_homework_ids
+                ]
 
                 _LOGGER.warning(
                     "Updating the property calendar_homework of '%s@%s' failed - OSError: %s",
@@ -755,8 +745,7 @@ class WebUntis:
             )
             self.today = today
         except OSError as error:
-            if not self.is_qr:
-                self.today = [None, None]
+            self.today = [None, None]
 
             _LOGGER.warning(
                 "Updating the property today-sensor of '%s@%s' failed - OSError: %s",

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -334,50 +334,63 @@ class WebUntis:
             for i in self.exclude_data_run:
                 self.exclude_data_(i)
 
-        if (
-            getattr(self, "is_qr", False)
-            and self.qr_data
-            and "jsessionid" not in self.session.config
-        ):
-            client_session = async_get_clientsession(self._hass)
-            self.session, jsessionid = await ExtendedSession.async_create_from_qr(
-                self.qr_data,
-                client_session,
-            )
-            self._hass.config_entries.async_update_entry(
-                self._config,
-                data={
-                    **self._config.data,
-                    "jsessionid": jsessionid,
-                    **self.session.login_result,
-                },
-            )
+        if getattr(self, "is_qr", False) and self.qr_data:
+            try:
+                client_session = async_get_clientsession(self._hass)
 
-        login_error = await self._hass.async_add_executor_job(self.webuntis_login)
+                # 1. Neue QR-Session async anfordern
+                new_session, jsessionid = await ExtendedSession.async_create_from_qr(
+                    self.qr_data,
+                    client_session,
+                )
 
-        if login_error:
-            if str(login_error) == "bad credentials":
-                self.issue = True
-                ir.async_create_issue(
-                    self._hass,
-                    DOMAIN,
-                    "bad_credentials",
-                    is_fixable=True,
-                    severity=ir.IssueSeverity.ERROR,
-                    translation_key="bad_credentials",
+                # 2. Session zuweisen
+                self.session = new_session
+
+                # 3. WICHTIG: Flag für internen Zustand setzen, damit executor_jobs
+                # die neue Session sofort als valide erkennen
+                self._loged_in = True
+
+                self._hass.config_entries.async_update_entry(
+                    self._config,
                     data={
-                        "unique_id": self.unique_id,
-                        "config_data": dict(self._config.data),
-                        "entry_id": self._config.entry_id,
+                        **self._config.data,
+                        "jsessionid": jsessionid,
+                        **self.session.login_result,
                     },
                 )
-            return
-        elif self.issue:
-            _LOGGER.info("delete issue bad_credentials")
-            ir.async_delete_issue(self._hass, DOMAIN, "bad_credentials")
-            self.issue = False
+            except Exception as err:
+                _LOGGER.error("QR-Code Re-Authentication fehlgeschlagen: %s", err)
+                self._last_status_request_failed = True
+                # Hier greift dein gewünschter Reset auf None:
+                self.next_class = None
+                self.day_json = None
+                self.calendar_events = []
+                return
+        else:
+            login_error = await self._hass.async_add_executor_job(self.webuntis_login)
 
-        # _LOGGER.debug("updating data")
+            if login_error:
+                if str(login_error) == "bad credentials":
+                    self.issue = True
+                    ir.async_create_issue(
+                        self._hass,
+                        DOMAIN,
+                        "bad_credentials",
+                        is_fixable=True,
+                        severity=ir.IssueSeverity.ERROR,
+                        translation_key="bad_credentials",
+                        data={
+                            "unique_id": self.unique_id,
+                            "config_data": dict(self._config.data),
+                            "entry_id": self._config.entry_id,
+                        },
+                    )
+                return
+            elif self.issue:
+                _LOGGER.info("delete issue bad_credentials")
+                ir.async_delete_issue(self._hass, DOMAIN, "bad_credentials")
+                self.issue = False
 
         try:
             self.schoolyears = await self._hass.async_add_executor_job(
@@ -459,7 +472,7 @@ class WebUntis:
                 self.get_student_id
             )
         except OSError as error:
-            self.subjects = []
+            self.student_id = []
 
             _LOGGER.warning(
                 "Updating the student_id of '%s@%s' failed - OSError: %s",

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 from datetime import date, datetime, timedelta
 from typing import Any
 import uuid
+import asyncio
 
 from homeassistant.components.calendar import CalendarEvent
 from homeassistant.config_entries import ConfigEntry
@@ -338,17 +339,16 @@ class WebUntis:
             try:
                 client_session = async_get_clientsession(self._hass)
 
-                # 1. Neue QR-Session async anfordern
                 new_session, jsessionid = await ExtendedSession.async_create_from_qr(
                     self.qr_data,
                     client_session,
                 )
 
-                # 2. Session zuweisen
+                # Wait a moment to ensure the session is fully established before proceeding
+                await asyncio.sleep(1)
+
                 self.session = new_session
 
-                # 3. WICHTIG: Flag für internen Zustand setzen, damit executor_jobs
-                # die neue Session sofort als valide erkennen
                 self._loged_in = True
 
                 self._hass.config_entries.async_update_entry(
@@ -362,7 +362,6 @@ class WebUntis:
             except Exception as err:
                 _LOGGER.error("QR-Code Re-Authentication fehlgeschlagen: %s", err)
                 self._last_status_request_failed = True
-                # Hier greift dein gewünschter Reset auf None:
                 self.next_class = None
                 self.day_json = None
                 self.calendar_events = []
@@ -472,7 +471,7 @@ class WebUntis:
                 self.get_student_id
             )
         except OSError as error:
-            self.student_id = []
+            self.student_id = None
 
             _LOGGER.warning(
                 "Updating the student_id of '%s@%s' failed - OSError: %s",

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -507,6 +507,8 @@ class WebUntis:
                     error,
                 )
 
+            param_list = []
+
             try:
                 (
                     self.calendar_homework,
@@ -516,6 +518,7 @@ class WebUntis:
                 )
             except OSError as error:
                 self.calendar_homework = []
+                param_list = []
 
                 _LOGGER.warning(
                     "Updating the property calendar_homework of '%s@%s' failed - OSError: %s",

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 # pylint: disable=maybe-no-member
 from webuntis import errors
 from .utils.web_untis_extended import ExtendedSession
+from .utils.qrLogin import QrData, parse_qr_code
 from .utils.homework import return_homework_events
 from .utils.exams import return_exam_events
 from .utils.schoolyears import resolve_schoolyear
@@ -175,6 +176,32 @@ class WebUntis:
         self.school = config.data["school"]
         self.username = config.data["username"]
         self.password = config.data.get("password", "")
+        self.is_qr = config.data.get("login_method") == "qr"
+        self.qr_data = None
+        if self.is_qr:
+            if config.data.get("qr_key"):
+                self.qr_data = QrData(
+                    server=self.server.removeprefix("https://").removeprefix("http://"),
+                    school=self.school,
+                    user=self.username,
+                    key=config.data["qr_key"],
+                    school_number=config.data.get("qr_school_number"),
+                )
+            elif config.data.get("qr_payload"):
+                try:
+                    self.qr_data = parse_qr_code(config.data["qr_payload"])
+                except ValueError:
+                    _LOGGER.error(
+                        "Stored QR login data for '%s@%s' is invalid; reconfigure the integration",
+                        self.school,
+                        self.username,
+                    )
+            else:
+                _LOGGER.error(
+                    "QR login secret is missing for '%s@%s'; reconfigure the integration",
+                    self.school,
+                    self.username,
+                )
         self.timetable_source = config.data["timetable_source"]
         self.timetable_source_id = config.data["timetable_source_id"]
         self.title = config.title
@@ -222,11 +249,11 @@ class WebUntis:
             "useragent": "foo",
             "school": self.school,
         }
-        if config.data.get("jsessionid"):
+        if config.data.get("jsessionid") and not self.is_qr:
             session_kwargs["jsessionid"] = config.data["jsessionid"]
 
         self.session = ExtendedSession(**session_kwargs)
-        if config.data.get("jsessionid"):
+        if config.data.get("jsessionid") and not self.is_qr:
             self.session.login_result = {
                 key: config.data[key]
                 for key in ("personType", "personId", "klasseId")
@@ -307,9 +334,24 @@ class WebUntis:
             for i in self.exclude_data_run:
                 self.exclude_data_(i)
 
-        if getattr(self, "is_qr", False) and "jsessionid" not in self.session.config:
+        if (
+            getattr(self, "is_qr", False)
+            and self.qr_data
+            and "jsessionid" not in self.session.config
+        ):
             client_session = async_get_clientsession(self._hass)
-            await self.session.async_refresh_qr(self.qr_data, client_session)
+            self.session, jsessionid = await ExtendedSession.async_create_from_qr(
+                self.qr_data,
+                client_session,
+            )
+            self._hass.config_entries.async_update_entry(
+                self._config,
+                data={
+                    **self._config.data,
+                    "jsessionid": jsessionid,
+                    **self.session.login_result,
+                },
+            )
 
         login_error = await self._hass.async_add_executor_job(self.webuntis_login)
 

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import date, datetime, timedelta
 from typing import Any
 import uuid
-import asyncio
 
 from homeassistant.components.calendar import CalendarEvent
 from homeassistant.config_entries import ConfigEntry
@@ -297,6 +297,7 @@ class WebUntis:
 
         # Callback for stopping periodic update.
         self._stop_periodic_update: CALLBACK_TYPE | None = None
+        self._qr_session_lock = asyncio.Lock()
 
         self.lesson_change_callback = None
         self.homework_change_callback = None
@@ -328,27 +329,61 @@ class WebUntis:
         # Notify sensors about new data.
         async_dispatcher_send(self._hass, self.signal_name)
 
-    async def _async_status_request(self) -> None:
-        """Request status and update properties."""
+    def _session_has_jsessionid(self) -> bool:
+        """Return True when current session has a usable JSESSIONID."""
+        session = getattr(self, "session", None)
+        if session is None:
+            return False
 
-        if self.exclude_data_run:
-            for i in self.exclude_data_run:
-                self.exclude_data_(i)
+        config = getattr(session, "config", None)
+        if config is None:
+            return False
 
-        if getattr(self, "is_qr", False) and self.qr_data:
+        try:
+            return bool(config["jsessionid"])
+        except Exception:
+            return False
+
+    async def _async_ensure_valid_session(self, force_refresh: bool = False) -> bool:
+        """Ensure QR session exists and is valid, reauthenticating when required."""
+        if not self.is_qr:
+            return True
+
+        if not self.qr_data:
+            _LOGGER.error(
+                "QR login data is missing for '%s@%s'; reconfigure the integration",
+                self.school,
+                self.username,
+            )
+            self._last_status_request_failed = True
+            return False
+
+        if (
+            not force_refresh
+            and self._loged_in
+            and getattr(self, "session", None)
+            and self._session_has_jsessionid()
+        ):
+            return True
+
+        async with self._qr_session_lock:
+            if (
+                not force_refresh
+                and self._loged_in
+                and getattr(self, "session", None)
+                and self._session_has_jsessionid()
+            ):
+                return True
+
             try:
                 client_session = async_get_clientsession(self._hass)
-
                 new_session, jsessionid = await ExtendedSession.async_create_from_qr(
                     self.qr_data,
                     client_session,
                 )
 
-                # Wait a moment to ensure the session is fully established before proceeding
-                await asyncio.sleep(1)
-
+                # Only assign after async_create_from_qr finished successfully.
                 self.session = new_session
-
                 self._loged_in = True
 
                 self._hass.config_entries.async_update_entry(
@@ -359,12 +394,34 @@ class WebUntis:
                         **self.session.login_result,
                     },
                 )
+                return True
             except Exception as err:
                 _LOGGER.error("QR-Code Re-Authentication fehlgeschlagen: %s", err)
                 self._last_status_request_failed = True
-                self.next_class = None
-                self.day_json = None
-                self.calendar_events = []
+                return False
+
+    async def _async_add_executor_job_with_retry(self, func_name, func, *args):
+        try:
+            return await self._hass.async_add_executor_job(func, *args)
+        except Exception as err:
+            _LOGGER.debug("Session vermutlich abgelaufen (%s), erneuere direkt...", err)
+
+            if self.is_qr:
+                await self._async_ensure_valid_session(force_refresh=True)
+            else:
+                await self._hass.async_add_executor_job(self.webuntis_login)
+
+            return await self._hass.async_add_executor_job(func, *args)
+
+    async def _async_status_request(self) -> None:
+        """Request status and update properties."""
+
+        if self.exclude_data_run:
+            for i in self.exclude_data_run:
+                self.exclude_data_(i)
+
+        if self.is_qr:
+            if not await self._async_ensure_valid_session():
                 return
         else:
             login_error = await self._hass.async_add_executor_job(self.webuntis_login)
@@ -392,12 +449,28 @@ class WebUntis:
                 self.issue = False
 
         try:
-            self.schoolyears = await self._hass.async_add_executor_job(
-                self.session.schoolyears
+            schoolyears = await self._async_add_executor_job_with_retry(
+                "schoolyears",
+                lambda: self.session.schoolyears(),
             )
-            self.current_schoolyear = await self._hass.async_add_executor_job(
-                resolve_schoolyear, self.schoolyears
+            current_schoolyear = await self._hass.async_add_executor_job(
+                resolve_schoolyear,
+                schoolyears,
             )
+
+            if not current_schoolyear and self.is_qr:
+                if await self._async_ensure_valid_session(force_refresh=True):
+                    schoolyears = await self._async_add_executor_job_with_retry(
+                        "schoolyears",
+                        lambda: self.session.schoolyears(),
+                    )
+                    current_schoolyear = await self._hass.async_add_executor_job(
+                        resolve_schoolyear,
+                        schoolyears,
+                    )
+
+            self.schoolyears = schoolyears
+            self.current_schoolyear = current_schoolyear
 
             if not self.current_schoolyear:
                 # Login error, set all properties to unknown.
@@ -441,11 +514,14 @@ class WebUntis:
             )
 
         try:
-            self.subjects = await self._hass.async_add_executor_job(
-                self.session.subjects
+            subjects = await self._async_add_executor_job_with_retry(
+                "subjects",
+                lambda: self.session.subjects(),
             )
+            self.subjects = subjects
         except OSError as error:
-            self.subjects = []
+            if not self.is_qr:
+                self.subjects = []
 
             _LOGGER.warning(
                 "Updating the subjects of '%s@%s' failed - OSError: %s",
@@ -455,9 +531,14 @@ class WebUntis:
             )
 
         try:
-            self.klassen = await self._hass.async_add_executor_job(self.session.klassen)
+            klassen = await self._async_add_executor_job_with_retry(
+                "klassen",
+                lambda: self.session.klassen(),
+            )
+            self.klassen = klassen
         except OSError as error:
-            self.klassen = []
+            if not self.is_qr:
+                self.klassen = []
 
             _LOGGER.warning(
                 "Updating the classes (klassen) of '%s@%s' failed - OSError: %s",
@@ -467,11 +548,14 @@ class WebUntis:
             )
 
         try:
-            self.student_id = await self._hass.async_add_executor_job(
-                self.get_student_id
+            student_id = await self._async_add_executor_job_with_retry(
+                "student_id",
+                lambda: self.get_student_id(),
             )
+            self.student_id = student_id
         except OSError as error:
-            self.student_id = None
+            if not self.is_qr:
+                self.student_id = None
 
             _LOGGER.warning(
                 "Updating the student_id of '%s@%s' failed - OSError: %s",
@@ -481,9 +565,14 @@ class WebUntis:
             )
 
         try:
-            self.next_class = await self._hass.async_add_executor_job(self._next_class)
+            next_class = await self._async_add_executor_job_with_retry(
+                "next_class",
+                lambda: self._next_class(),
+            )
+            self.next_class = next_class
         except OSError as error:
-            self.next_class = None
+            if not self.is_qr:
+                self.next_class = None
 
             _LOGGER.warning(
                 "Updating the property next_class of '%s@%s' failed - OSError: %s",
@@ -493,11 +582,14 @@ class WebUntis:
             )
 
         try:
-            self.next_lesson_to_wake_up = await self._hass.async_add_executor_job(
-                self._next_lesson_to_wake_up
+            next_lesson_to_wake_up = await self._async_add_executor_job_with_retry(
+                "next_lesson_to_wake_up",
+                lambda: self._next_lesson_to_wake_up(),
             )
+            self.next_lesson_to_wake_up = next_lesson_to_wake_up
         except OSError as error:
-            self.next_lesson_to_wake_up = None
+            if not self.is_qr:
+                self.next_lesson_to_wake_up = None
 
             _LOGGER.warning(
                 "Updating the property next_lesson_to_wake_up of '%s@%s' failed - OSError: %s",
@@ -507,11 +599,14 @@ class WebUntis:
             )
 
         try:
-            self.next_day_json = await self._hass.async_add_executor_job(
-                self._next_day_json
+            next_day_json = await self._async_add_executor_job_with_retry(
+                "next_day_json",
+                lambda: self._next_day_json(),
             )
+            self.next_day_json = next_day_json
         except OSError as error:
-            self.next_day_json = None
+            if not self.is_qr:
+                self.next_day_json = None
 
             _LOGGER.warning(
                 "Updating the property next_day_json of '%s@%s' failed - OSError: %s",
@@ -521,9 +616,14 @@ class WebUntis:
             )
 
         try:
-            self.day_json = await self._hass.async_add_executor_job(self._day_json)
+            day_json = await self._async_add_executor_job_with_retry(
+                "day_json",
+                lambda: self._day_json(),
+            )
+            self.day_json = day_json
         except OSError as error:
-            self.day_json = None
+            if not self.is_qr:
+                self.day_json = None
 
             _LOGGER.warning(
                 "Updating the property day_json of '%s@%s' failed - OSError: %s",
@@ -533,16 +633,18 @@ class WebUntis:
             )
 
         try:
-            self.calendar_events = await self._hass.async_add_executor_job(
-                self._get_events
+            calendar_events = await self._async_add_executor_job_with_retry(
+                "calendar_events",
+                lambda: self._get_events(),
             )
             self.calendar_events = compact_list(
-                self.calendar_events,
+                calendar_events,
                 "calendar",
                 timedelta(minutes=self.lesson_compacting_tolerance),
             )
         except OSError as error:
-            self.calendar_events = []
+            if not self.is_qr:
+                self.calendar_events = []
 
             _LOGGER.warning(
                 "Updating the property calendar_events of '%s@%s' failed - OSError: %s",
@@ -553,11 +655,14 @@ class WebUntis:
 
         if self.timetable_source != "teacher":
             try:
-                self.calendar_exams = await self._hass.async_add_executor_job(
-                    return_exam_events, self
+                calendar_exams = await self._async_add_executor_job_with_retry(
+                    "calendar_exams",
+                    lambda: return_exam_events(self),
                 )
+                self.calendar_exams = calendar_exams
             except OSError as error:
-                self.calendar_exams = []
+                if not self.is_qr:
+                    self.calendar_exams = []
 
                 _LOGGER.warning(
                     "Updating the property calendar_exams of '%s@%s' failed - OSError: %s",
@@ -570,14 +675,22 @@ class WebUntis:
 
             try:
                 (
-                    self.calendar_homework,
+                    calendar_homework,
                     param_list,
-                ) = await self._hass.async_add_executor_job(
-                    return_homework_events, self
+                ) = await self._async_add_executor_job_with_retry(
+                    "calendar_homework",
+                    lambda: return_homework_events(self),
                 )
+                self.calendar_homework = calendar_homework
             except OSError as error:
-                self.calendar_homework = []
-                param_list = []
+                if not self.is_qr:
+                    self.calendar_homework = []
+                    param_list = []
+                else:
+                    param_list = [
+                        {"homework_id": homework_id}
+                        for homework_id in self.calendar_homework_ids
+                    ]
 
                 _LOGGER.warning(
                     "Updating the property calendar_homework of '%s@%s' failed - OSError: %s",
@@ -625,9 +738,14 @@ class WebUntis:
                 self.calendar_homework_ids.append(event["homework_id"])
 
         try:
-            self.today = await self._hass.async_add_executor_job(self._today)
+            today = await self._async_add_executor_job_with_retry(
+                "today",
+                lambda: self._today(),
+            )
+            self.today = today
         except OSError as error:
-            self.today = [None, None]
+            if not self.is_qr:
+                self.today = [None, None]
 
             _LOGGER.warning(
                 "Updating the property today-sensor of '%s@%s' failed - OSError: %s",

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Callable, Mapping
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 import uuid
 
@@ -50,6 +50,8 @@ from .utils.utils import compact_list, async_notify
 from .utils.web_untis import get_timetable_object
 
 PLATFORMS = [Platform.SENSOR, Platform.CALENDAR, Platform.EVENT]
+
+QR_SESSION_REFRESH_INTERVAL = timedelta(minutes=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -363,6 +365,9 @@ class WebUntis:
             and self._loged_in
             and getattr(self, "session", None)
             and self._session_has_jsessionid()
+            and self._qr_session_created_at is not None
+            and datetime.now(timezone.utc) - self._qr_session_created_at
+            < QR_SESSION_REFRESH_INTERVAL
         ):
             return True
 
@@ -372,6 +377,9 @@ class WebUntis:
                 and self._loged_in
                 and getattr(self, "session", None)
                 and self._session_has_jsessionid()
+                and self._qr_session_created_at is not None
+                and datetime.now(timezone.utc) - self._qr_session_created_at
+                < QR_SESSION_REFRESH_INTERVAL
             ):
                 return True
 
@@ -385,6 +393,7 @@ class WebUntis:
                 # Only assign after async_create_from_qr finished successfully.
                 self.session = new_session
                 self._loged_in = True
+                self._qr_session_created_at = datetime.now(timezone.utc)
 
                 self._hass.config_entries.async_update_entry(
                     self._config,

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -657,19 +657,24 @@ class WebUntis:
             self._last_status_request_failed = True
             return error
 
-    def webuntis_logout(self):
-        """Logout from WebUntis (skipped for QR sessions)."""
-        self.updating = max(0, self.updating - 1)
+    def webuntis_logout(self) -> None:
+        """Logout from WebUntis."""
 
+        # Do not logout for qr code sessions
         if getattr(self, "is_qr", False):
-            return
+            _LOGGER.debug(
+                "Skipping webuntis_logout for QR code session to keep JSESSIONID active"
+            )
+            return None
 
-        if not self.keep_logged_in and self.updating == 0:
+        # Normal logout
+        if self._loged_in:
             try:
                 self.session.logout()
-            except Exception as error:
-                _LOGGER.debug("Logout failed: %s", error)
-            self._loged_in = False
+            except Exception as err:
+                _LOGGER.warning("Error during WebUntis logout: %s", err)
+            finally:
+                self._loged_in = False
 
     def get_student_id(self):
         if self.timetable_source == "student":

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -19,8 +19,10 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
-from homeassistant.data_entry_flow import section as data_entry_flow_section
 from homeassistant.helpers import selector
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .utils.qrLogin import WebUntisQrClient, parse_qr_payload
 
 from .const import (
     CONFIG_ENTRY_VERSION,
@@ -47,6 +49,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = CONFIG_ENTRY_VERSION
 
     _session_temp = None
+    _qr_session_temp = None
     _user_input_temp = {}
     _source_id = None
     _reconfigure = False
@@ -99,7 +102,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         user_input: dict[str, Any] | None = None,
         errors: dict[str, Any] | None = None,
     ) -> FlowResult | config_entries.ConfigFlowResult:
-        # First step: accept a school name or search query
+        """Show the initial login method menu."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["manual_login", "qr_login"],
+        )
+
+    async def async_step_manual_login(
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
+    ) -> FlowResult | config_entries.ConfigFlowResult:
+        """Handle the school search and username/password login flow."""
         errors = errors or {}
 
         if user_input is not None:
@@ -107,11 +121,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             query = user_input.get("school", "").strip()
 
-            # School is selected
+            # School is selected from a previous search.
             selected = user_input.get("school_choice")
             if selected:
                 selected_school = next(
-                    (school for school in self._search_results if school["login_name"] == selected),
+                    (
+                        school
+                        for school in self._search_results
+                        if school["login_name"] == selected
+                    ),
                     None,
                 )
                 if selected_school:
@@ -121,30 +139,33 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                     return await self.async_step_auth()
 
-            # Do search
+            # Search for schools.
             results = await self.hass.async_add_executor_job(search_schools, query)
             self._search_results = results.get("schools", [])
             if not self._search_results:
-                # no results -> show error
                 _LOGGER.debug("No schools found for query: %s", query)
                 errors["school"] = "school_not_found"
-
             elif len(self._search_results) == 1:
-                _LOGGER.debug("One school found: %s", self._search_results[0].get("name"))
+                _LOGGER.debug(
+                    "One school found: %s", self._search_results[0].get("name")
+                )
                 if self._search_results[0].get("login_name").lower() == query.lower():
                     _LOGGER.debug("Name matches query, skipping choose_school step")
                     self._selected_school = self._search_results[0]
-                    self._user_input_temp["school"] = self._search_results[0].get("login_name")
-                    self._user_input_temp["server"] = self._search_results[0].get("server")
+                    self._user_input_temp["school"] = self._search_results[0].get(
+                        "login_name"
+                    )
+                    self._user_input_temp["server"] = self._search_results[0].get(
+                        "server"
+                    )
                     return await self.async_step_auth()
 
         user_input = user_input or {}
 
-        schema = {
+        schema: dict[Any, Any] = {
             vol.Required("school", default=user_input.get("school", "")): str
         }
 
-        # Show dropdown if there are search results
         if getattr(self, "_search_results", None):
             schema[vol.Optional("school_choice")] = selector.SelectSelector(
                 selector.SelectSelectorConfig(
@@ -159,8 +180,63 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_show_form(
-            step_id="user",
+            step_id="manual_login",
             data_schema=vol.Schema(schema),
+            errors=errors,
+        )
+
+    async def async_step_qr_login(
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
+    ) -> FlowResult | config_entries.ConfigFlowResult:
+        """Handle QR-code based login."""
+        errors = errors or {}
+
+        if user_input is not None:
+            payload = user_input.get("qr_payload", "").strip()
+            try:
+                creds = parse_qr_payload(payload)
+                qr_session = async_get_clientsession(self.hass)
+                qr_client = WebUntisQrClient(creds, qr_session)
+                user_data, jsessionid = await qr_client.async_login()
+
+                session = qr_client.create_session(jsessionid)
+                session.login_result = WebUntisQrClient.login_result_from_user_data(
+                    user_data
+                )
+
+                self._session_temp = session
+                self._user_input_temp = {
+                    "login_method": "qr",
+                    "server": f"https://{creds.server}",
+                    "school": creds.school,
+                    "username": creds.user,
+                    "password": "",
+                    "jsessionid": jsessionid,
+                }
+                if session.login_result:
+                    self._user_input_temp.update(session.login_result)
+
+                return await self.async_step_timetable_source()
+            except ValueError:
+                errors["base"] = "invalid_qr_format"
+            except webuntis.errors.NotLoggedInError:
+                errors["base"] = "invalid_auth"
+            except Exception as err:
+                _LOGGER.error("QR login failed: %s", err)
+                errors["base"] = "cannot_connect"
+
+        user_input = user_input or {}
+        return self.async_show_form(
+            step_id="qr_login",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        "qr_payload", default=user_input.get("qr_payload", "")
+                    ): str,
+                }
+            ),
             errors=errors,
         )
 
@@ -477,13 +553,24 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             session = webuntis.Session(
                 server=credentials["server"],
                 school=credentials["school"],
-                username=credentials["username"],
-                password=credentials["password"],
+                username=credentials.get("username", ""),
+                password=credentials.get("password", ""),
+                jsessionid=credentials.get("jsessionid"),
                 useragent="home-assistant",
             )
-            await hass.async_add_executor_job(session.login)
+            if credentials.get("jsessionid"):
+                session.login_result = {
+                    key: credentials[key]
+                    for key in ("personType", "personId", "klasseId")
+                    if key in credentials
+                }
+                await hass.async_add_executor_job(session.schoolyears)
+            else:
+                await hass.async_add_executor_job(session.login)
         except webuntis.errors.BadCredentialsError:
             errors["base"] = "bad_credentials"
+        except webuntis.errors.NotLoggedInError:
+            errors["base"] = "invalid_auth"
         except requests.exceptions.ConnectionError as exc:
             _LOGGER.error("webuntis.Session connection error: %s", exc)
             errors["base"] = "cannot_connect"
@@ -510,7 +597,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             if user_input["timetable_source"] == "personal":
                 session.my_timetable(start=day, end=day)
-                self._source_id = session.login_result["personId"]
+                login_result = getattr(session, "login_result", {}) or {}
+                self._source_id = login_result.get("personId")
+                if self._source_id is None:
+                    return {"base": "no_personal_timetable"}
             else:
                 timetable_object = get_timetable_object(
                     user_input["timetable_source_id"],

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -225,6 +225,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_qr_format"
             except webuntis.errors.NotLoggedInError:
                 errors["base"] = "invalid_auth"
+                _LOGGER.error("QR login failed: Not logged in error")
             except Exception as err:
                 _LOGGER.error("QR login failed: %s", err)
                 errors["base"] = "cannot_connect"

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -57,6 +57,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     _reconfigure = False
     _search_results = []
     _selected_school = None
+    _login_method = None
 
     @staticmethod
     @callback
@@ -104,11 +105,35 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         user_input: dict[str, Any] | None = None,
         errors: dict[str, Any] | None = None,
     ) -> FlowResult | config_entries.ConfigFlowResult:
-        """Show the initial login method menu."""
+        """Step 1: Auswahl zwischen manuellem Login und QR-Code Login."""
         return self.async_show_menu(
             step_id="user",
-            menu_options=["manual_login", "qr_login"],
+            menu_options=["manual_login", "qr_menu"],
         )
+
+    async def async_step_qr_menu(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Step 2: Untermenü für die zwei QR-Code Optionen."""
+        return self.async_show_menu(
+            step_id="qr_menu",
+            menu_options=["choose_qr_string", "choose_qr_manual"],
+        )
+
+    async def async_step_choose_qr_string(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Nutzer hat QR-Code gewählt -> Flagge setzen und weiterleiten."""
+        self._login_method = "qr_string"
+        return await self.async_step_qr_login()
+
+    async def async_step_choose_qr_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Nutzer hat manuelle Eingabe gewählt -> Flagge setzen und weiterleiten."""
+        self._login_method = "qr_manual"
+        return await self.async_step_qr_login()
 
     async def async_step_manual_login(
         self,
@@ -192,11 +217,21 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         user_input: dict[str, Any] | None = None,
         errors: dict[str, Any] | None = None,
     ) -> FlowResult | config_entries.ConfigFlowResult:
-        """Handle QR-code based login."""
+        """Handle QR-code based login with dynamic UI fields."""
         errors = errors or {}
 
         if user_input is not None:
-            payload = user_input.get("qr_payload", "").strip()
+            if self._login_method == "qr_manual":
+                server = user_input.get("url", "").strip()
+                school = user_input.get("school", "").strip()
+                user = user_input.get("user", "").strip()
+                key = user_input.get("key", "").strip()
+                school_num = user_input.get("school_number", "").strip()
+
+                payload = f"untis://setschool?url={server}&school={school}&user={user}&key={key}&schoolNumber={school_num}"
+            else:
+                payload = user_input.get("qr_payload", "").strip()
+
             try:
                 creds = parse_qr_code(payload)
                 qr_session = async_get_clientsession(self.hass)
@@ -231,15 +266,31 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
 
         user_input = user_input or {}
-        return self.async_show_form(
-            step_id="qr_login",
-            data_schema=vol.Schema(
+
+        if getattr(self, "_login_method", None) == "qr_manual":
+            schema = vol.Schema(
+                {
+                    vol.Required(
+                        "school_number", default=user_input.get("school_number", "")
+                    ): str,
+                    vol.Required("school", default=user_input.get("school", "")): str,
+                    vol.Required("url", default=user_input.get("url", "")): str,
+                    vol.Required("user", default=user_input.get("user", "")): str,
+                    vol.Required("key", default=user_input.get("key", "")): str,
+                }
+            )
+        else:
+            schema = vol.Schema(
                 {
                     vol.Required(
                         "qr_payload", default=user_input.get("qr_payload", "")
                     ): str,
                 }
-            ),
+            )
+
+        return self.async_show_form(
+            step_id="qr_login",
+            data_schema=schema,
             errors=errors,
         )
 

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -22,7 +22,8 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .utils.qrLogin import WebUntisQrLogin, parse_qr_code
+from .utils.qrLogin import parse_qr_code
+from .utils.web_untis_extended import ExtendedSession
 
 from .const import (
     CONFIG_ENTRY_VERSION,
@@ -198,12 +199,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 creds = parse_qr_code(payload)
                 qr_session = async_get_clientsession(self.hass)
-                qr_client = WebUntisQrLogin(creds, qr_session)
-                user_data, jsessionid = await qr_client.async_login()
-
-                session = qr_client.create_session(jsessionid)
-                session.login_result = WebUntisQrLogin.login_result_from_user_data(
-                    user_data
+                session, jsessionid = await ExtendedSession.async_create_from_qr(
+                    creds,
+                    qr_session,
                 )
 
                 self._session_temp = session

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -173,7 +173,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 selector.SelectSelectorConfig(
                     options=[
                         selector.SelectOptionDict(
-                            label=f'{school["name"]} ({school["address"]})',
+                            label=f"{school['name']} ({school['address']})",
                             value=school["login_name"],
                         )
                         for school in self._search_results
@@ -239,7 +239,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_auth(self, user_input: dict[str, Any] | None = None, errors: dict[str, Any] | None = None) -> FlowResult | config_entries.ConfigFlowResult:
+    async def async_step_auth(
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
+    ) -> FlowResult | config_entries.ConfigFlowResult:
         """Authenticate with username/password after school is chosen."""
         errors = errors or {}
 
@@ -256,13 +260,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="auth",
-                description_placeholders={
-                    "school_name": self._selected_school["name"],
-                },
+            description_placeholders={
+                "school_name": self._selected_school["name"],
+            },
             data_schema=vol.Schema(
                 {
-                    vol.Required("username", default=user_input.get("username", "")): str,
-                    vol.Required("password", default=user_input.get("password", "")): str,
+                    vol.Required(
+                        "username", default=user_input.get("username", "")
+                    ): str,
+                    vol.Required(
+                        "password", default=user_input.get("password", "")
+                    ): str,
                 }
             ),
             errors=errors,
@@ -508,7 +516,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
         session = None
-        server =  credentials.get("server") or credentials.get("advanced_options", {}).get("server") # keep fallback for advanced_options for backward compatibility
+        server = credentials.get("server") or credentials.get(
+            "advanced_options", {}
+        ).get("server")  # keep fallback for advanced_options for backward compatibility
 
         if not server:
             # use server from selected school (provided by the untis search)
@@ -587,19 +597,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         session: webuntis.Session = self._session_temp
         user_input = self._user_input_temp
 
-        day = datetime.date.today()
         schoolyears = session.schoolyears()
         current_schoolyear = resolve_schoolyear(schoolyears)
+        print("current schoolyear", current_schoolyear)
         if not current_schoolyear:
             if schoolyears:
                 day = schoolyears[-1].start.date()
             else:
                 return {"base": "no_school_year"}
+        else:
+            day = current_schoolyear.start.date()
+            print("day", day)
 
         try:
             if user_input["timetable_source"] == "personal":
                 session.my_timetable(start=day, end=day)
                 login_result = getattr(session, "login_result", {}) or {}
+                print("login result: %s", login_result)
                 self._source_id = login_result.get("personId")
                 if self._source_id is None:
                     return {"base": "no_personal_timetable"}
@@ -630,6 +644,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             _LOGGER.error("Error testing timetable: %s", exc)
             return {"base": "unknown"}
+
 
 OPTIONS_MENU = [
     "filter",

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -212,6 +212,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "school": creds.school,
                     "username": creds.user,
                     "password": "",
+                    "qr_key": creds.key,
+                    "qr_school_number": creds.school_number,
+                    "qr_payload": payload,
                     "jsessionid": jsessionid,
                 }
                 if session.login_result:

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -22,7 +22,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .utils.qrLogin import WebUntisQrClient, parse_qr_payload
+from .utils.qrLogin import WebUntisQrLogin, parse_qr_code
 
 from .const import (
     CONFIG_ENTRY_VERSION,
@@ -196,13 +196,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             payload = user_input.get("qr_payload", "").strip()
             try:
-                creds = parse_qr_payload(payload)
+                creds = parse_qr_code(payload)
                 qr_session = async_get_clientsession(self.hass)
-                qr_client = WebUntisQrClient(creds, qr_session)
+                qr_client = WebUntisQrLogin(creds, qr_session)
                 user_data, jsessionid = await qr_client.async_login()
 
                 session = qr_client.create_session(jsessionid)
-                session.login_result = WebUntisQrClient.login_result_from_user_data(
+                session.login_result = WebUntisQrLogin.login_result_from_user_data(
                     user_data
                 )
 

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -599,7 +599,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schoolyears = session.schoolyears()
         current_schoolyear = resolve_schoolyear(schoolyears)
-        print("current schoolyear", current_schoolyear)
         if not current_schoolyear:
             if schoolyears:
                 day = schoolyears[-1].start.date()
@@ -607,13 +606,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return {"base": "no_school_year"}
         else:
             day = current_schoolyear.start.date()
-            print("day", day)
 
         try:
             if user_input["timetable_source"] == "personal":
                 session.my_timetable(start=day, end=day)
                 login_result = getattr(session, "login_result", {}) or {}
-                print("login result: %s", login_result)
                 self._source_id = login_result.get("personId")
                 if self._source_id is None:
                     return {"base": "no_personal_timetable"}

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -600,15 +600,24 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         session: webuntis.Session = self._session_temp
         user_input = self._user_input_temp
 
+        _LOGGER.error(
+            "Testing timetable for source: %s", user_input["timetable_source"]
+        )
+
         schoolyears = session.schoolyears()
         current_schoolyear = resolve_schoolyear(schoolyears)
         if not current_schoolyear:
             if schoolyears:
-                day = schoolyears[-1].start.date()
+                day = datetime.datetime.now
             else:
                 return {"base": "no_school_year"}
         else:
-            day = current_schoolyear.start.date()
+            today = datetime.datetime.now().date()
+            day = (
+                today
+                if today >= schoolyears[0].start.date()
+                else schoolyears[0].start.date()
+            )  # if today is after the first schoolyear, use today, otherwise use the start of the first schoolyear
 
         try:
             if user_input["timetable_source"] == "personal":

--- a/custom_components/webuntis/const.py
+++ b/custom_components/webuntis/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "webuntis"
 
-CONFIG_ENTRY_VERSION = 21
+CONFIG_ENTRY_VERSION = 22
 
 DEFAULT_OPTIONS = {
     "lesson_long_name": True,

--- a/custom_components/webuntis/manifest.json
+++ b/custom_components/webuntis/manifest.json
@@ -2,7 +2,7 @@
   "domain": "webuntis",
   "name": "Web Untis",
   "codeowners": [
-    "@JonasJoKuJonas"
+    "@JonasJoKuJonas", "@mrtncode"
   ],
   "config_flow": true,
   "documentation": "https://github.com/JonasJoKuJonas/homeassistant-WebUntis/",

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -32,7 +32,7 @@
         },
         "menu_options": {
           "manual_login": "Manueller Login",
-          "qr_login": "Mit QR-Code anmelden"
+          "qr_menu": "Mit QR-Code anmelden"
         },
         "description": "Wähle aus, wie du dich anmelden möchtest."
       },
@@ -41,6 +41,13 @@
         "data": {
           "username": "Benutzername",
           "password": "Passwort"
+        }
+      },
+      "qr_menu": {
+        "description": "Wähle aus, wie du dich mit einem QR-Code anmelden möchtest.",
+        "menu_options": {
+          "qr_login": "QR-Code-Inhalt einfügen",
+          "qr_manual": "Einzeldaten manuell eingeben"
         }
       },
       "timetable_source": {
@@ -90,9 +97,14 @@
         }
       },
       "qr_login": {
-        "description": "Füge den QR-Inhalt aus WebUntis ein.",
+        "description": "Du kannst den QR-Code in der WebUntis-Webapp unter **Dein Name > Freigaben** finden.",
         "data": {
-          "qr_payload": "QR-Code-Inhalt"
+          "qr_payload": "QR-Code-Inhalt. Du kannst ihn erhalten, indem du den QR-Code scannst und den Inhalt kopierst.",
+          "school": "Schule",
+          "school_number": "Schulnummer",
+          "url": "URL",
+          "user": "Benutzer",
+          "key": "Key"
         },
         "data_description": {
           "qr_payload": "Der QR-Inhalt beginnt normalerweise mit `untis://`."

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -4,44 +4,77 @@
       "already_configured": "Der Sensor ist bereits konfiguriert."
     },
     "error": {
-      "cannot_connect": "Verbindung fehlgeschlagen. Überprüfe die Server-Domain.",
-      "invalid_auth": "Ungültige Authentifizierung",
       "bad_credentials": "Ungültiger Benutzername und/oder Passwort",
-      "school_not_found": "Es wurden keine Schulen gefunden. Versuche es mit einem anderen Suchbegriff.",
-      "name_split_error": "Ungültiger Name. Versuche \"Vorname, Nachname\".",
-      "student_not_found": "Schüler nicht gefunden. Überprüfen Sie den Namen oder wählen Sie eine andere Quelle.",
-      "teacher_not_found": "Lehrer nicht gefunden. Überprüfen Sie den Namen oder wählen Sie eine andere Quelle.",
+      "cannot_connect": "Verbindung fehlgeschlagen. Überprüfe die Server-Domain.",
       "class_not_found": "Klasse nicht gefunden. Überprüfen Sie die Klasse oder wählen Sie eine andere Quelle.",
+      "invalid_auth": "Ungültige Authentifizierung",
+      "invalid_qr_format": "Ungültiger QR-Code-Inhalt",
+      "name_split_error": "Ungültiger Name. Versuche \"Vorname, Nachname\".",
+      "no_personal_timetable": "Für diesen Benutzer ist kein persönlicher Stundenplan verfügbar. Bitte wähle eine andere Quelle.",
       "no_rights_for_timetable": "Keine Rechte für den Stundenplan. Wählen Sie einen anderen Namen oder eine andere Quelle.",
       "no_school_year": "Konfiguration über die Klasse nur während eines aktiven Schuljahres möglich.",
-      "no_personal_timetable": "Für diesen Benutzer ist kein persönlicher Stundenplan verfügbar. Bitte wähle eine andere Quelle.",
-      "unknown": "Unerwarteter Fehler. Logs für weitere Informationen ansehen.",
-      "invalid_qr_format": "Ungültiger QR-Code-Inhalt"
+      "school_not_found": "Es wurden keine Schulen gefunden. Versuche es mit einem anderen Suchbegriff.",
+      "student_not_found": "Schüler nicht gefunden. Überprüfen Sie den Namen oder wählen Sie eine andere Quelle.",
+      "teacher_not_found": "Lehrer nicht gefunden. Überprüfen Sie den Namen oder wählen Sie eine andere Quelle.",
+      "unknown": "Unerwarteter Fehler. Logs für weitere Informationen ansehen."
     },
     "step": {
-      "user": {
+      "auth": {
+        "data": {
+          "password": "Passwort",
+          "username": "Benutzername"
+        },
+        "description": "Bitte gib deine Untis Zugangsdaten für **{school_name}** ein."
+      },
+      "manual_login": {
         "data": {
           "school": "Schulname oder Suchbegriff",
+          "school_choice": "Wähle deine Schule:",
           "timetable_source": "Stundenplan-Quelle",
-          "timetable_source_id": "Voller Name/Klasse",
-          "school_choice": "Wähle deine Schule:"
+          "timetable_source_id": "Voller Name/Klasse"
         },
         "data_description": {
-          "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein",
-          "school": "Du musst nicht den vollständigen Namen der Schule eingeben. Die Integration sucht nach Schulen, die mit deiner Eingabe übereinstimmen."
+          "school": "Du musst nicht den vollständigen Namen der Schule eingeben. Die Integration sucht nach Schulen, die mit deiner Eingabe übereinstimmen.",
+          "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein"
         },
-        "menu_options": {
-          "manual_login": "Manueller Login",
-          "qr_menu": "Mit QR-Code anmelden"
-        },
-        "description": "Wähle aus, wie du dich anmelden möchtest."
+        "description": "Suche nach deiner Schule oder wähle sie aus den Suchergebnissen."
       },
-      "auth": {
-        "description": "Bitte gib deine Untis Zugangsdaten für **{school_name}** ein.",
+      "pick_klasse": {
         "data": {
-          "username": "Benutzername",
-          "password": "Passwort"
-        }
+          "back": "Zurück",
+          "klasse": "Klasse"
+        },
+        "description": "Klasse eingeben"
+      },
+      "pick_student": {
+        "data": {
+          "back": "Zurück",
+          "fore_name": "Vorname",
+          "surname": "Nachname"
+        },
+        "description": "Name eines Schülers eingeben"
+      },
+      "pick_teacher": {
+        "data": {
+          "back": "Zurück",
+          "fore_name": "Vorname",
+          "surname": "Nachname"
+        },
+        "description": "Name eines Lehrers eingeben"
+      },
+      "qr_login": {
+        "data": {
+          "key": "Key",
+          "qr_payload": "QR-Code-Inhalt. Du kannst ihn erhalten, indem du den QR-Code scannst und den Inhalt kopierst.",
+          "school": "Schule",
+          "school_number": "Schulnummer",
+          "url": "URL",
+          "user": "Benutzer"
+        },
+        "data_description": {
+          "qr_payload": "Der QR-Inhalt beginnt normalerweise mit `untis://`."
+        },
+        "description": "Du kannst den QR-Code in der WebUntis-Webapp unter **Dein Name > Freigaben** finden."
       },
       "qr_menu": {
         "description": "Wähle aus, wie du dich mit einem QR-Code anmelden möchtest.",
@@ -50,333 +83,42 @@
           "qr_manual": "Einzeldaten manuell eingeben"
         }
       },
-      "timetable_source": {
-        "data": {
-          "timetable_source": "Wähle die Datenquelle für den Stundenplan:"
-        }
-      },
-      "pick_student": {
-        "description": "Name eines Schülers eingeben",
-        "data": {
-          "surname": "Nachname",
-          "fore_name": "Vorname",
-          "back": "Zurück"
-        }
-      },
-      "pick_teacher": {
-        "description": "Name eines Lehrers eingeben",
-        "data": {
-          "surname": "Nachname",
-          "fore_name": "Vorname",
-          "back": "Zurück"
-        }
-      },
-      "pick_klasse": {
-        "description": "Klasse eingeben",
-        "data": {
-          "klasse": "Klasse",
-          "back": "Zurück"
-        }
-      },
       "reconfigure": {
         "data": {
           "password": "Passwort"
         }
       },
-      "manual_login": {
-        "description": "Suche nach deiner Schule oder wähle sie aus den Suchergebnissen.",
+      "timetable_source": {
+        "data": {
+          "timetable_source": "Wähle die Datenquelle für den Stundenplan:"
+        }
+      },
+      "user": {
         "data": {
           "school": "Schulname oder Suchbegriff",
+          "school_choice": "Wähle deine Schule:",
           "timetable_source": "Stundenplan-Quelle",
-          "timetable_source_id": "Voller Name/Klasse",
-          "school_choice": "Wähle deine Schule:"
+          "timetable_source_id": "Voller Name/Klasse"
         },
         "data_description": {
-          "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein",
-          "school": "Du musst nicht den vollständigen Namen der Schule eingeben. Die Integration sucht nach Schulen, die mit deiner Eingabe übereinstimmen."
-        }
-      },
-      "qr_login": {
-        "description": "Du kannst den QR-Code in der WebUntis-Webapp unter **Dein Name > Freigaben** finden.",
-        "data": {
-          "qr_payload": "QR-Code-Inhalt. Du kannst ihn erhalten, indem du den QR-Code scannst und den Inhalt kopierst.",
-          "school": "Schule",
-          "school_number": "Schulnummer",
-          "url": "URL",
-          "user": "Benutzer",
-          "key": "Key"
+          "school": "Du musst nicht den vollständigen Namen der Schule eingeben. Die Integration sucht nach Schulen, die mit deiner Eingabe übereinstimmen.",
+          "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein"
         },
-        "data_description": {
-          "qr_payload": "Der QR-Inhalt beginnt normalerweise mit `untis://`."
-        }
-      }
-    }
-  },
-  "options": {
-    "error": {
-      "unknown_service": "Service-ID nicht gefunden.",
-      "not_a_dict": "Muss ein Dictionary sein",
-      "notification_invalid": "Benachrichtigung konnte nicht gesendet werden. Siehe Logs für mehr Infos.",
-      "unknown": "Unerwarteter Fehler"
-    },
-    "step": {
-      "init": {
+        "description": "Wähle aus, wie du dich anmelden möchtest.",
         "menu_options": {
-          "filter": "Filter",
-          "calendar": "Kalender",
-          "lesson": "Stunden-Darstellung",
-          "backend": "Backend",
-          "notify_menu": "Notify Menü"
-        }
-      },
-      "filter": {
-        "title": "Filter-Einstellungen",
-        "description": "Einstellungen zum Herausfiltern unerwünschter Stunden.",
-        "data": {
-          "filter_mode": "Fächer Filter",
-          "filter_subjects": "Fächer Filter - Fächer",
-          "filter_klassen": "Fächer Filter - Klassen",
-          "filter_description": "Fächer Filter - Beschreibung",
-          "invalid_subjects": "Kein Fach",
-          "exclude_filter_comparison": "Stunden für Benachrichtigungen und Events nicht filtern"
-        },
-        "data_description": {
-          "filter_mode": "Gilt sowohl für Fach- als auch Klassen-Filter",
-          "filter_description": "Verstecke Stunden, die die folgenden Ausdrücke in der Beschreibung enthalten. (Kommagetrennte Liste) \nWird nicht von Black/Whitelist beeinflusst.",
-          "invalid_subjects": "Erlaube Stunden ohne Fach",
-          "exclude_filter_comparison": "Dadurch können Events und Benachrichtigungen auch bei Änderungen von gefilterten Stunden ausgelöst werden."
-        }
-      },
-      "lesson": {
-        "title": "Stunden-Darstellungs-Einstellungen",
-        "description": "Einstellungen, wie die Stunden angezeigt werden.\nDies wird auf den Kalender und die Benachrichtigungen angewendet.",
-        "data": {
-          "lesson_long_name": "Langer Name",
-          "lesson_replace_name": "Stunden-Name ersetzen",
-          "lesson_add_teacher": "Füge Lehrer-Kürzel zu Stunde hinzu",
-          "lesson_compacting_tolerance": "Max. Pausenzeit für Doppelstunde"
-        },
-        "data_description": {
-          "lesson_replace_name": "Bsp:\nM: Mathe",
-          "lesson_add_teacher": "Wähle Stunden aus, die mit Lehrer-Kürze angezeigt werden sollen.",
-          "lesson_compacting_tolerance": "Aufeinanderfolgende identische Stunden werden bei kürzerer Unterbrechung zusammengefasst"
-        }
-      },
-      "calendar": {
-        "title": "Kalender-Einstellungen",
-        "description": "Einstellungen zur Kalender Darstellung.",
-        "data": {
-          "calendar_show_cancelled_lessons": "Kalender - Ausfallende Stunden",
-          "calendar_description": "Kalender - Beschreibung",
-          "calendar_room": "Kalender - Ort",
-          "calendar_show_room_change": "Kalender - Zimmerwechsel",
-          "calendar_replace_name": "Ereignisnamen ersetzen"
-        },
-        "data_description": {
-          "calendar_show_cancelled_lessons": "Zeige ausfallende Stunden im Kalender an.",
-          "calendar_description": "Bestimme, was in der Beschreibung eines Kalender-Events stehen soll.",
-          "calendar_room": "Bestimme, was im Kalender als Ort angezeigt wird.",
-          "calendar_show_room_change": "Zeige Zimmerwechsel im Kalender an.",
-          "calendar_replace_name": "Bsp:\nCancelled: ❌"
-        }
-      },
-      "backend": {
-        "title": "Server-Einstellungen",
-        "description": "Einstellungen zur Verbindung und Datenverarbeitung.",
-        "data": {
-          "keep_loged_in": "Eingeloggt bleiben",
-          "generate_json": "JSON generieren",
-          "exclude_data": "Daten von request ausschließen"
-        },
-        "data_description": {
-          "keep_loged_in": "Versucht die Session zu speichern. (BETA)",
-          "generate_json": "Generiere JSON in Sensor-Attribute - nur aktivieren, wenn es benötigt wird.",
-          "exclude_data": "Diese Option wird automatisch gesetzt, wenn der Benutzer keine Rechte hat, um das spamen von Fehlermeldungen zu vermeiden."
-        }
-      },
-      "edit_notify_service": {
-        "title": "Notify Menü",
-        "description": "füge oder bearbeite einen Benachrichtigungs-Dienst",
-        "data": {
-          "name": "Name",
-          "entity_id": "Notify Service ID",
-          "target": "Plattformspezifische Targetdaten",
-          "data": "Plattformspezifische Benachrichtigungs-Daten",
-          "template": "Benachrichtigungs-Template",
-          "options": "Benachrichtigen, wenn"
-        },
-        "data_description": {
-          "data": "Bsp:\nnotification_icon: mdi:school-outline",
-          "entity_id": "Bsp: notify.discord",
-          "template": "Kann Benachrichtigungs-Daten überschreiben"
-        }
-      },
-      "notify_menu": {
-        "title": "Notify Dienst",
-        "menu_options": {
-          "edit_notify_service": "Notify Dienst hinzufügen",
-          "edit_notify_service_select": "Notify Dienst bearbeiten",
-          "remove_notify_service": "Notify Dienst löschen",
-          "test_notify_service": "Notify Dienst testen"
+          "manual_login": "Manueller Login",
+          "qr_menu": "Mit QR-Code anmelden"
         }
       }
-    }
-  },
-  "selector": {
-    "notify_options": {
-      "options": {
-        "homework": "Hausaufgaben hinzugefügt",
-        "code": "Stunden-Status Änderung",
-        "rooms": "Raum Änderung",
-        "teachers": "Lehrer Änderung",
-        "cancelled": "Stunde fällt aus",
-        "subject": "Fach Änderung",
-        "lstext": "Stundentext Änderung",
-        "info": "Stundeninfo Änderung"
-      }
-    },
-    "timetable_source": {
-      "options": {
-        "personal": "Persönlicher Stundenplan (empfohlen)",
-        "student": "Schüler",
-        "klasse": "Klasse",
-        "teacher": "Lehrer",
-        "subject": "Fach",
-        "room": "Raum"
-      }
-    },
-    "notify_template": {
-      "options": {
-        "message_title": "Nachricht & Titel",
-        "message": "Nachricht",
-        "discord": "Discord"
-      }
-    },
-    "calendar_description": {
-      "options": {
-        "none": "Keine",
-        "json": "JSON",
-        "lesson_info": "Stunden Info",
-        "class_name_short": "Klassen Name (kurz)",
-        "class_name_long": "Klassen Name (lang)"
-      }
-    }
-  },
-  "issues": {
-    "bad_credentials": {
-      "fix_flow": {
-        "error": {
-          "cannot_connect": "Verbindung fehlgeschlagen. Überprüfe die Server-Domain.",
-          "invalid_auth": "Ungültige Authentifizierung",
-          "bad_credentials": "Ungültiges Passwort",
-          "unknown": "Unerwarteter Fehler"
-        },
-        "step": {
-          "confirm": {
-            "description": "Bitte gib das neue Passwort ein!",
-            "title": "Das Passwort wurde geändert",
-            "data": {
-              "password": "Passwort"
-            }
-          }
-        }
-      },
-      "title": "Das Passwort wurde geändert"
-    }
-  },
-  "services": {
-    "get_timetable": {
-      "description": "Stundenplan in einem bestimmten Zeitraum abrufen.",
-      "fields": {
-        "device_id": {
-          "name": "Gerät",
-          "description": "Eine Instanz auswählen"
-        },
-        "start": {
-          "name": "Start",
-          "description": "Start des Zeitraums"
-        },
-        "end": {
-          "name": "Ende",
-          "description": "Ende des Zeitraums"
-        },
-        "apply_filter": {
-          "name": "Filter aktivieren",
-          "description": "Wendet den Filter aus den Einstellungen auf die Ergebnisse an"
-        },
-        "show_cancelled": {
-          "name": "Zeige ausgefallene Stunden",
-          "description": "Zeige ausgefallene Stunden im Ergebnis"
-        },
-        "compact_result": {
-          "name": "Vereinfachte Ergebnisse",
-          "description": "Fasse Doppelstunden im Ergebnis zusammen"
-        },
-        "compact_tolerance_minutes": {
-          "name": "Toleranz für das Zusammenfassen (Minuten)",
-          "description": "Zeitliche Toleranz, um Stunden als Doppelstunden zusammenzufassen. (Nur relevant, wenn 'Vereinfachte Ergebnisse' aktiviert ist)"
-        }
-      },
-      "name": "Stundenplan abrufen"
-    },
-    "count_lessons": {
-      "description": "Stunden in einem Zeitraum zählen.",
-      "fields": {
-        "device_id": {
-          "name": "Gerät",
-          "description": "Eine Instanz auswählen"
-        },
-        "start": {
-          "name": "Start",
-          "description": "Start des Zeitraums"
-        },
-        "end": {
-          "name": "Ende",
-          "description": "Ende des Zeitraums"
-        },
-        "apply_filter": {
-          "name": "Filter aktivieren",
-          "description": "Wendet den Filter aus den Einstellungen auf die Ergebnisse an"
-        },
-        "count_cancelled": {
-          "name": "Zähle ausgefallene Stunden",
-          "description": "Zähle ausgefallene Stunden"
-        }
-      },
-      "name": "Stunden zählen"
-    },
-    "get_schoolyears": {
-      "description": "WebUntis Schuljahre abrufen.",
-      "fields": {
-        "device_id": {
-          "name": "Gerät",
-          "description": "Eine Instanz auswählen"
-        }
-      },
-      "name": "Schuljahre abrufen"
     }
   },
   "entity": {
-    "sensor": {
-      "next_class": {
-        "name": "Nächste Stunde"
-      },
-      "next_lesson_to_wake_up": {
-        "name": "Nächste Stunde zum Aufstehen"
-      },
-      "today_school_start": {
-        "name": "Heutiger Schulbeginn"
-      },
-      "today_school_end": {
-        "name": "Heutiges Schulende"
-      }
-    },
     "calendar": {
-      "homework": {
-        "name": "Hausaufgaben"
-      },
       "exam": {
         "name": "Prüfungen"
+      },
+      "homework": {
+        "name": "Hausaufgaben"
       }
     },
     "event": {
@@ -385,13 +127,13 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "code": "Stunden-Status Änderung",
-              "rooms": "Raum Änderung",
-              "teachers": "Lehrer Änderung",
               "cancelled": "Stundenausfall",
+              "code": "Stunden-Status Änderung",
+              "info": "Info-Text Änderung",
               "lstext": "Stundentext Änderung",
+              "rooms": "Raum Änderung",
               "subject": "Fach Änderung",
-              "info": "Info-Text Änderung"
+              "teachers": "Lehrer Änderung"
             }
           }
         }
@@ -406,6 +148,264 @@
           }
         }
       }
+    },
+    "sensor": {
+      "next_class": {
+        "name": "Nächste Stunde"
+      },
+      "next_lesson_to_wake_up": {
+        "name": "Nächste Stunde zum Aufstehen"
+      },
+      "today_school_end": {
+        "name": "Heutiges Schulende"
+      },
+      "today_school_start": {
+        "name": "Heutiger Schulbeginn"
+      }
+    }
+  },
+  "issues": {
+    "bad_credentials": {
+      "fix_flow": {
+        "error": {
+          "bad_credentials": "Ungültiges Passwort",
+          "cannot_connect": "Verbindung fehlgeschlagen. Überprüfe die Server-Domain.",
+          "invalid_auth": "Ungültige Authentifizierung",
+          "unknown": "Unerwarteter Fehler"
+        },
+        "step": {
+          "confirm": {
+            "data": {
+              "password": "Passwort"
+            },
+            "description": "Bitte gib das neue Passwort ein!",
+            "title": "Das Passwort wurde geändert"
+          }
+        }
+      },
+      "title": "Das Passwort wurde geändert"
+    }
+  },
+  "options": {
+    "error": {
+      "not_a_dict": "Muss ein Dictionary sein",
+      "notification_invalid": "Benachrichtigung konnte nicht gesendet werden. Siehe Logs für mehr Infos.",
+      "unknown": "Unerwarteter Fehler",
+      "unknown_service": "Service-ID nicht gefunden."
+    },
+    "step": {
+      "backend": {
+        "data": {
+          "exclude_data": "Daten von request ausschließen",
+          "generate_json": "JSON generieren",
+          "keep_loged_in": "Eingeloggt bleiben"
+        },
+        "data_description": {
+          "exclude_data": "Diese Option wird automatisch gesetzt, wenn der Benutzer keine Rechte hat, um das spamen von Fehlermeldungen zu vermeiden.",
+          "generate_json": "Generiere JSON in Sensor-Attribute - nur aktivieren, wenn es benötigt wird.",
+          "keep_loged_in": "Versucht die Session zu speichern. (BETA)"
+        },
+        "description": "Einstellungen zur Verbindung und Datenverarbeitung.",
+        "title": "Server-Einstellungen"
+      },
+      "calendar": {
+        "data": {
+          "calendar_description": "Kalender - Beschreibung",
+          "calendar_replace_name": "Ereignisnamen ersetzen",
+          "calendar_room": "Kalender - Ort",
+          "calendar_show_cancelled_lessons": "Kalender - Ausfallende Stunden",
+          "calendar_show_room_change": "Kalender - Zimmerwechsel"
+        },
+        "data_description": {
+          "calendar_description": "Bestimme, was in der Beschreibung eines Kalender-Events stehen soll.",
+          "calendar_replace_name": "Bsp:\nCancelled: ❌",
+          "calendar_room": "Bestimme, was im Kalender als Ort angezeigt wird.",
+          "calendar_show_cancelled_lessons": "Zeige ausfallende Stunden im Kalender an.",
+          "calendar_show_room_change": "Zeige Zimmerwechsel im Kalender an."
+        },
+        "description": "Einstellungen zur Kalender Darstellung.",
+        "title": "Kalender-Einstellungen"
+      },
+      "edit_notify_service": {
+        "data": {
+          "data": "Plattformspezifische Benachrichtigungs-Daten",
+          "entity_id": "Notify Service ID",
+          "name": "Name",
+          "options": "Benachrichtigen, wenn",
+          "target": "Plattformspezifische Targetdaten",
+          "template": "Benachrichtigungs-Template"
+        },
+        "data_description": {
+          "data": "Bsp:\nnotification_icon: mdi:school-outline",
+          "entity_id": "Bsp: notify.discord",
+          "template": "Kann Benachrichtigungs-Daten überschreiben"
+        },
+        "description": "füge oder bearbeite einen Benachrichtigungs-Dienst",
+        "title": "Notify Menü"
+      },
+      "filter": {
+        "data": {
+          "exclude_filter_comparison": "Stunden für Benachrichtigungen und Events nicht filtern",
+          "filter_description": "Fächer Filter - Beschreibung",
+          "filter_klassen": "Fächer Filter - Klassen",
+          "filter_mode": "Fächer Filter",
+          "filter_subjects": "Fächer Filter - Fächer",
+          "invalid_subjects": "Kein Fach"
+        },
+        "data_description": {
+          "exclude_filter_comparison": "Dadurch können Events und Benachrichtigungen auch bei Änderungen von gefilterten Stunden ausgelöst werden.",
+          "filter_description": "Verstecke Stunden, die die folgenden Ausdrücke in der Beschreibung enthalten. (Kommagetrennte Liste) \nWird nicht von Black/Whitelist beeinflusst.",
+          "filter_mode": "Gilt sowohl für Fach- als auch Klassen-Filter",
+          "invalid_subjects": "Erlaube Stunden ohne Fach"
+        },
+        "description": "Einstellungen zum Herausfiltern unerwünschter Stunden.",
+        "title": "Filter-Einstellungen"
+      },
+      "init": {
+        "menu_options": {
+          "backend": "Backend",
+          "calendar": "Kalender",
+          "filter": "Filter",
+          "lesson": "Stunden-Darstellung",
+          "notify_menu": "Notify Menü"
+        }
+      },
+      "lesson": {
+        "data": {
+          "lesson_add_teacher": "Füge Lehrer-Kürzel zu Stunde hinzu",
+          "lesson_compacting_tolerance": "Max. Pausenzeit für Doppelstunde",
+          "lesson_long_name": "Langer Name",
+          "lesson_replace_name": "Stunden-Name ersetzen"
+        },
+        "data_description": {
+          "lesson_add_teacher": "Wähle Stunden aus, die mit Lehrer-Kürze angezeigt werden sollen.",
+          "lesson_compacting_tolerance": "Aufeinanderfolgende identische Stunden werden bei kürzerer Unterbrechung zusammengefasst",
+          "lesson_replace_name": "Bsp:\nM: Mathe"
+        },
+        "description": "Einstellungen, wie die Stunden angezeigt werden.\nDies wird auf den Kalender und die Benachrichtigungen angewendet.",
+        "title": "Stunden-Darstellungs-Einstellungen"
+      },
+      "notify_menu": {
+        "menu_options": {
+          "edit_notify_service": "Notify Dienst hinzufügen",
+          "edit_notify_service_select": "Notify Dienst bearbeiten",
+          "remove_notify_service": "Notify Dienst löschen",
+          "test_notify_service": "Notify Dienst testen"
+        },
+        "title": "Notify Dienst"
+      }
+    }
+  },
+  "selector": {
+    "calendar_description": {
+      "options": {
+        "class_name_long": "Klassen Name (lang)",
+        "class_name_short": "Klassen Name (kurz)",
+        "json": "JSON",
+        "lesson_info": "Stunden Info",
+        "none": "Keine"
+      }
+    },
+    "notify_options": {
+      "options": {
+        "cancelled": "Stunde fällt aus",
+        "code": "Stunden-Status Änderung",
+        "homework": "Hausaufgaben hinzugefügt",
+        "info": "Stundeninfo Änderung",
+        "lstext": "Stundentext Änderung",
+        "rooms": "Raum Änderung",
+        "subject": "Fach Änderung",
+        "teachers": "Lehrer Änderung"
+      }
+    },
+    "notify_template": {
+      "options": {
+        "discord": "Discord",
+        "message": "Nachricht",
+        "message_title": "Nachricht & Titel"
+      }
+    },
+    "timetable_source": {
+      "options": {
+        "klasse": "Klasse",
+        "personal": "Persönlicher Stundenplan (empfohlen)",
+        "room": "Raum",
+        "student": "Schüler",
+        "subject": "Fach",
+        "teacher": "Lehrer"
+      }
+    }
+  },
+  "services": {
+    "count_lessons": {
+      "description": "Stunden in einem Zeitraum zählen.",
+      "fields": {
+        "apply_filter": {
+          "description": "Wendet den Filter aus den Einstellungen auf die Ergebnisse an",
+          "name": "Filter aktivieren"
+        },
+        "count_cancelled": {
+          "description": "Zähle ausgefallene Stunden",
+          "name": "Zähle ausgefallene Stunden"
+        },
+        "device_id": {
+          "description": "Eine Instanz auswählen",
+          "name": "Gerät"
+        },
+        "end": {
+          "description": "Ende des Zeitraums",
+          "name": "Ende"
+        },
+        "start": {
+          "description": "Start des Zeitraums",
+          "name": "Start"
+        }
+      },
+      "name": "Stunden zählen"
+    },
+    "get_schoolyears": {
+      "description": "WebUntis Schuljahre abrufen.",
+      "fields": {
+        "device_id": {
+          "description": "Eine Instanz auswählen",
+          "name": "Gerät"
+        }
+      },
+      "name": "Schuljahre abrufen"
+    },
+    "get_timetable": {
+      "description": "Stundenplan in einem bestimmten Zeitraum abrufen.",
+      "fields": {
+        "apply_filter": {
+          "description": "Wendet den Filter aus den Einstellungen auf die Ergebnisse an",
+          "name": "Filter aktivieren"
+        },
+        "compact_result": {
+          "description": "Fasse Doppelstunden im Ergebnis zusammen",
+          "name": "Vereinfachte Ergebnisse"
+        },
+        "compact_tolerance_minutes": {
+          "description": "Zeitliche Toleranz, um Stunden als Doppelstunden zusammenzufassen. (Nur relevant, wenn 'Vereinfachte Ergebnisse' aktiviert ist)",
+          "name": "Toleranz für das Zusammenfassen (Minuten)"
+        },
+        "device_id": {
+          "description": "Eine Instanz auswählen",
+          "name": "Gerät"
+        },
+        "end": {
+          "description": "Ende des Zeitraums",
+          "name": "Ende"
+        },
+        "show_cancelled": {
+          "description": "Zeige ausgefallene Stunden im Ergebnis",
+          "name": "Zeige ausgefallene Stunden"
+        },
+        "start": {
+          "description": "Start des Zeitraums",
+          "name": "Start"
+        }
+      },
+      "name": "Stundenplan abrufen"
     }
   }
 }

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -79,8 +79,8 @@
       "qr_menu": {
         "description": "Wähle aus, wie du dich mit einem QR-Code anmelden möchtest.",
         "menu_options": {
-          "qr_login": "QR-Code-Inhalt einfügen",
-          "qr_manual": "Einzeldaten manuell eingeben"
+          "choose_qr_string": "QR-Code-Inhalt einfügen",
+          "choose_qr_manual": "Einzeldaten manuell eingeben"
         }
       },
       "reconfigure": {

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -106,7 +106,7 @@
         },
         "description": "Wähle aus, wie du dich anmelden möchtest.",
         "menu_options": {
-          "manual_login": "Manueller Login",
+          "manual_login": "Normaler Login (empfohlen)",
           "qr_menu": "Mit QR-Code anmelden"
         }
       }

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -15,7 +15,8 @@
       "no_rights_for_timetable": "Keine Rechte für den Stundenplan. Wählen Sie einen anderen Namen oder eine andere Quelle.",
       "no_school_year": "Konfiguration über die Klasse nur während eines aktiven Schuljahres möglich.",
       "no_personal_timetable": "Für diesen Benutzer ist kein persönlicher Stundenplan verfügbar. Bitte wähle eine andere Quelle.",
-      "unknown": "Unerwarteter Fehler. Logs für weitere Informationen ansehen."
+      "unknown": "Unerwarteter Fehler. Logs für weitere Informationen ansehen.",
+      "invalid_qr_format": "Ung?ltige QR-Code-Nutzlast"
     },
     "step": {
       "user": {
@@ -28,7 +29,12 @@
         "data_description": {
           "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein",
           "school": "Du musst nicht den vollständigen Namen der Schule eingeben. Die Integration sucht nach Schulen, die mit deiner Eingabe übereinstimmen."
-        }
+        },
+        "menu_options": {
+          "manual_login": "Manueller Login",
+          "qr_login": "Mit QR-Code anmelden"
+        },
+        "description": "W?hle aus, wie du dich anmelden m?chtest."
       },
       "auth": {
         "description": "Bitte gib deine Untis Zugangsdaten für **{school_name}** ein.",
@@ -68,6 +74,28 @@
       "reconfigure": {
         "data": {
           "password": "Passwort"
+        }
+      },
+      "manual_login": {
+        "description": "Suche nach deiner Schule oder w?hle sie aus den Suchergebnissen.",
+        "data": {
+          "school": "Schulname oder Suchbegriff",
+          "timetable_source": "Stundenplan-Quelle",
+          "timetable_source_id": "Voller Name/Klasse",
+          "school_choice": "Wähle deine Schule:"
+        },
+        "data_description": {
+          "timetable_source_id": "Geben Sie den vollständigen Namen des Schülers/Lehrers oder den Namen der Klasse ein",
+          "school": "Du musst nicht den vollständigen Namen der Schule eingeben. Die Integration sucht nach Schulen, die mit deiner Eingabe übereinstimmen."
+        }
+      },
+      "qr_login": {
+        "description": "F?ge die QR-Nutzlast aus der WebUntis-App ein.",
+        "data": {
+          "qr_payload": "QR-Code-Nutzlast"
+        },
+        "data_description": {
+          "qr_payload": "Die Nutzlast beginnt normalerweise mit `untis://`."
         }
       }
     }

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -16,7 +16,7 @@
       "no_school_year": "Konfiguration über die Klasse nur während eines aktiven Schuljahres möglich.",
       "no_personal_timetable": "Für diesen Benutzer ist kein persönlicher Stundenplan verfügbar. Bitte wähle eine andere Quelle.",
       "unknown": "Unerwarteter Fehler. Logs für weitere Informationen ansehen.",
-      "invalid_qr_format": "Ung?ltige QR-Code-Nutzlast"
+      "invalid_qr_format": "Ungültige QR-Code-Nutzlast"
     },
     "step": {
       "user": {
@@ -34,7 +34,7 @@
           "manual_login": "Manueller Login",
           "qr_login": "Mit QR-Code anmelden"
         },
-        "description": "W?hle aus, wie du dich anmelden m?chtest."
+        "description": "Wähle aus, wie du dich anmelden möchtest."
       },
       "auth": {
         "description": "Bitte gib deine Untis Zugangsdaten für **{school_name}** ein.",
@@ -77,7 +77,7 @@
         }
       },
       "manual_login": {
-        "description": "Suche nach deiner Schule oder w?hle sie aus den Suchergebnissen.",
+        "description": "Suche nach deiner Schule oder wähle sie aus den Suchergebnissen.",
         "data": {
           "school": "Schulname oder Suchbegriff",
           "timetable_source": "Stundenplan-Quelle",
@@ -90,7 +90,7 @@
         }
       },
       "qr_login": {
-        "description": "F?ge die QR-Nutzlast aus der WebUntis-App ein.",
+        "description": "Füge die QR-Nutzlast aus der WebUntis-App ein.",
         "data": {
           "qr_payload": "QR-Code-Nutzlast"
         },

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -16,7 +16,7 @@
       "no_school_year": "Konfiguration über die Klasse nur während eines aktiven Schuljahres möglich.",
       "no_personal_timetable": "Für diesen Benutzer ist kein persönlicher Stundenplan verfügbar. Bitte wähle eine andere Quelle.",
       "unknown": "Unerwarteter Fehler. Logs für weitere Informationen ansehen.",
-      "invalid_qr_format": "Ungültige QR-Code-Nutzlast"
+      "invalid_qr_format": "Ungültiger QR-Code-Inhalt"
     },
     "step": {
       "user": {
@@ -90,12 +90,12 @@
         }
       },
       "qr_login": {
-        "description": "Füge die QR-Nutzlast aus der WebUntis-App ein.",
+        "description": "Füge den QR-Inhalt aus WebUntis ein.",
         "data": {
-          "qr_payload": "QR-Code-Nutzlast"
+          "qr_payload": "QR-Code-Inhalt"
         },
         "data_description": {
-          "qr_payload": "Die Nutzlast beginnt normalerweise mit `untis://`."
+          "qr_payload": "Der QR-Inhalt beginnt normalerweise mit `untis://`."
         }
       }
     }

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -65,14 +65,14 @@
       "qr_login": {
         "data": {
           "key": "Key",
-          "qr_payload": "QR-Code-Inhalt. Du kannst ihn erhalten, indem du den QR-Code scannst und den Inhalt kopierst.",
+          "qr_payload": "QR-Code-Inhalt.",
           "school": "Schule",
           "school_number": "Schulnummer",
           "url": "URL",
           "user": "Benutzer"
         },
         "data_description": {
-          "qr_payload": "Der QR-Inhalt beginnt normalerweise mit `untis://`."
+          "qr_payload": "Der QR-Inhalt beginnt normalerweise mit `untis://`.\nDu kannst ihn erhalten, indem du den QR-Code scannst und den Inhalt kopierst."
         },
         "description": "Du kannst den QR-Code in der WebUntis-Webapp unter **Dein Name > Freigaben** finden."
       },

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -6,6 +6,7 @@
     "error": {
       "cannot_connect": "Failed to connect. Please check the host.",
       "invalid_auth": "Invalid authentication",
+      "invalid_qr_format": "Invalid QR code payload",
       "bad_credentials": "Invalid username and/or password",
       "school_not_found": "There are no schools matching your input. Please check the name or try a different search term.",
       "name_split_error": "Invalid name. Try \"first_name, last_name\".",
@@ -19,6 +20,11 @@
     },
     "step": {
       "user": {
+        "menu_options": {
+          "manual_login": "Manual login",
+          "qr_login": "Login with QRCode"
+        },
+        "description": "Choose how you want to sign in.",
         "data": {
           "school": "School name or search term",
           "timetable_source": "Timetable source",
@@ -28,6 +34,28 @@
         "data_description": {
           "timetable_source_id": "Enter the full name of the student/teacher or the class name",
           "school": "You do not have to enter the full name of the school.\nThe integration will search for schools matching your input."
+        }
+      },
+      "manual_login": {
+        "data": {
+          "school": "School name or search term",
+          "timetable_source": "Timetable source",
+          "timetable_source_id": "Full name/Class",
+          "school_choice": "Choose your school:"
+        },
+        "data_description": {
+          "timetable_source_id": "Enter the full name of the student/teacher or the class name",
+          "school": "You do not have to enter the full name of the school.\nThe integration will search for schools matching your input."
+        },
+        "description": "Search for your school or select it from the search results."
+      },
+      "qr_login": {
+        "description": "Paste the QR payload from the WebUntis app.",
+        "data": {
+          "qr_payload": "QRCode payload"
+        },
+        "data_description": {
+          "qr_payload": "The payload usually starts with `untis://`."
         }
       },
       "auth": {

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -106,7 +106,7 @@
         },
         "description": "Choose how you want to sign in.",
         "menu_options": {
-          "manual_login": "Manual login",
+          "manual_login": "Normal login (recommended)",
           "qr_menu": "Login with QRCode"
         }
       }

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -79,8 +79,8 @@
       "qr_menu": {
         "description": "Choose how you want to sign in with a QR code.",
         "menu_options": {
-          "choose_qr_manual": "Login with QRCode (Manual)",
-          "choose_qr_string": "Login with QRCode"
+          "choose_qr_manual": "Login with QRCode (Manual data)",
+          "choose_qr_string": "Login with QRCode content"
         }
       },
       "reconfigure": {

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -65,14 +65,14 @@
       "qr_login": {
         "data": {
           "key": "Key",
-          "qr_payload": "QRCode payload. You can get it by scanning the QRCode with your phone or by copying the payload",
+          "qr_payload": "QRCode payload",
           "school": "School",
           "school_number": "School number",
           "url": "Server URL",
           "user": "Username"
         },
         "data_description": {
-          "qr_payload": "The payload usually starts with `untis://`."
+          "qr_payload": "The payload usually starts with `untis://`.\nYou can get it by scanning the QRCode with your phone or by copying the payload"
         },
         "description": "You can find the QRCode in the WebUntis webapp app under **Your Name > Data access**."
       },

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -4,76 +4,87 @@
       "already_configured": "Device is already configured"
     },
     "error": {
+      "bad_credentials": "Invalid username and/or password",
       "cannot_connect": "Failed to connect. Please check the host.",
+      "class_not_found": "Class not found. Check the class or choose another source.",
       "invalid_auth": "Invalid authentication",
       "invalid_qr_format": "Invalid QR code payload",
-      "bad_credentials": "Invalid username and/or password",
-      "school_not_found": "There are no schools matching your input. Please check the name or try a different search term.",
       "name_split_error": "Invalid name. Try \"first_name, last_name\".",
-      "student_not_found": "Student not found. Check the name or choose another source.",
-      "teacher_not_found": "Teacher not found. Check the name or choose another source.",
-      "class_not_found": "Class not found. Check the class or choose another source.",
+      "no_personal_timetable": "No personal timetable is available for this user. Please choose another source.",
       "no_rights_for_timetable": "No rights for timetable. Choose another name or source.",
       "no_school_year": "Configuration via class only possible during an active school year.",
-      "no_personal_timetable": "No personal timetable is available for this user. Please choose another source.",
+      "school_not_found": "There are no schools matching your input. Please check the name or try a different search term.",
+      "student_not_found": "Student not found. Check the name or choose another source.",
+      "teacher_not_found": "Teacher not found. Check the name or choose another source.",
       "unknown": "Unexpected error. View logs for more information."
     },
     "step": {
-      "user": {
-        "menu_options": {
-          "manual_login": "Manual login",
-          "qr_menu": "Login with QRCode"
-        },
-        "description": "Choose how you want to sign in.",
+      "auth": {
         "data": {
-          "school": "School name or search term",
-          "timetable_source": "Timetable source",
-          "timetable_source_id": "Full name/Class",
-          "school_choice": "Choose your school:"
+          "password": "Password",
+          "username": "Username"
         },
-        "data_description": {
-          "timetable_source_id": "Enter the full name of the student/teacher or the class name",
-          "school": "You do not have to enter the full name of the school.\nThe integration will search for schools matching your input."
-        }
-      },
-      "qr_menu": {
-        "description": "Choose how you want to sign in with a QR code.",
-        "menu_options": {
-          "choose_qr_string": "Login with QRCode",
-          "choose_qr_manual": "Login with QRCode (Manual)"
-        }
+        "description": "Please enter your Untis credentials for **{school_name}**."
       },
       "manual_login": {
         "data": {
           "school": "School name or search term",
+          "school_choice": "Choose your school:",
           "timetable_source": "Timetable source",
-          "timetable_source_id": "Full name/Class",
-          "school_choice": "Choose your school:"
+          "timetable_source_id": "Full name/Class"
         },
         "data_description": {
-          "timetable_source_id": "Enter the full name of the student/teacher or the class name",
-          "school": "You do not have to enter the full name of the school.\nThe integration will search for schools matching your input."
+          "school": "You do not have to enter the full name of the school.\nThe integration will search for schools matching your input.",
+          "timetable_source_id": "Enter the full name of the student/teacher or the class name"
         },
         "description": "Search for your school or select it from the search results."
       },
-      "qr_login": {
-        "description": "You can find the QRCode in the WebUntis webapp app under **Your Name > Data access**.",
+      "pick_klasse": {
         "data": {
+          "back": "Back",
+          "klasse": "Class"
+        },
+        "description": "Enter a class name"
+      },
+      "pick_student": {
+        "data": {
+          "back": "Back",
+          "fore_name": "Fore Name",
+          "surname": "Surname"
+        },
+        "description": "Enter a Student Name"
+      },
+      "pick_teacher": {
+        "data": {
+          "back": "Back",
+          "fore_name": "Fore Name",
+          "surname": "Surname"
+        },
+        "description": "Enter a Teacher Name"
+      },
+      "qr_login": {
+        "data": {
+          "key": "Key",
           "qr_payload": "QRCode payload. You can get it by scanning the QRCode with your phone or by copying the payload",
           "school": "School",
           "school_number": "School number",
           "url": "Server URL",
-          "user": "Username",
-          "key": "Key"
+          "user": "Username"
         },
         "data_description": {
           "qr_payload": "The payload usually starts with `untis://`."
+        },
+        "description": "You can find the QRCode in the WebUntis webapp app under **Your Name > Data access**."
+      },
+      "qr_menu": {
+        "description": "Choose how you want to sign in with a QR code.",
+        "menu_options": {
+          "choose_qr_manual": "Login with QRCode (Manual)",
+          "choose_qr_string": "Login with QRCode"
         }
       },
-      "auth": {
-        "description": "Please enter your Untis credentials for **{school_name}**.",
+      "reconfigure": {
         "data": {
-          "username": "Username",
           "password": "Password"
         }
       },
@@ -82,302 +93,32 @@
           "timetable_source": "Select the timetable data source:"
         }
       },
-      "pick_student": {
-        "description": "Enter a Student Name",
+      "user": {
         "data": {
-          "surname": "Surname",
-          "fore_name": "Fore Name",
-          "back": "Back"
-        }
-      },
-      "pick_teacher": {
-        "description": "Enter a Teacher Name",
-        "data": {
-          "surname": "Surname",
-          "fore_name": "Fore Name",
-          "back": "Back"
-        }
-      },
-      "pick_klasse": {
-        "description": "Enter a class name",
-        "data": {
-          "klasse": "Class",
-          "back": "Back"
-        }
-      },
-      "reconfigure": {
-        "data": {
-          "password": "Password"
-        }
-      }
-    }
-  },
-  "options": {
-    "error": {
-      "unknown_service": "Service ID not found.",
-      "not_a_dict": "Has to be a dictionary",
-      "notification_invalid": "Notification could not be sent. See logs for more information.",
-      "unknown": "Unexpected error"
-    },
-    "step": {
-      "init": {
+          "school": "School name or search term",
+          "school_choice": "Choose your school:",
+          "timetable_source": "Timetable source",
+          "timetable_source_id": "Full name/Class"
+        },
+        "data_description": {
+          "school": "You do not have to enter the full name of the school.\nThe integration will search for schools matching your input.",
+          "timetable_source_id": "Enter the full name of the student/teacher or the class name"
+        },
+        "description": "Choose how you want to sign in.",
         "menu_options": {
-          "filter": "Filter",
-          "calendar": "Calendar",
-          "lesson": "Lesson Display",
-          "backend": "Backend",
-          "notify_menu": "Notify Menu"
-        }
-      },
-      "filter": {
-        "title": "Filter Settings",
-        "description": "Settings to filter out unwanted lessons.",
-        "data": {
-          "filter_mode": "Filter mode",
-          "filter_subjects": "Filter mode - subjects",
-          "filter_klassen": "Filter mode - classes",
-          "filter_description": "Filter mode - Description",
-          "invalid_subjects": "No Subjects",
-          "exclude_filter_comparison": "Do not filter lessons for notifications and events"
-        },
-        "data_description": {
-          "filter_mode": "Applies to both subject and class filters",
-          "filter_description": "Hide lessons that contain the following phrases in the description. (Comma-separated list) \nNot affected by blacklist/whitelist.",
-          "invalid_subjects": "Allow lessons with no subjects",
-          "exclude_filter_comparison": "When enabled the events and notifications are triggered for filtered lessons."
-        }
-      },
-      "lesson": {
-        "title": "Lesson Display Settings",
-        "description": "Settings to customize how the lesson is displayed. \nThis will be applied to the calendar and notifications.",
-        "data": {
-          "lesson_long_name": "Long name",
-          "lesson_replace_name": "Replace Lesson name",
-          "lesson_add_teacher": "Add Teacher to subject",
-          "lesson_compacting_tolerance": "Max. break time between double lessons"
-        },
-        "data_description": {
-          "lesson_replace_name": "e.g.,\nM: Math",
-          "lesson_add_teacher": "Select which subjects should be displayed with the teacher's name.",
-          "lesson_compacting_tolerance": "Identical consecutive lessons will be combined to double lessons if the break time is shorter than this value."
-        }
-      },
-      "calendar": {
-        "title": "Calendar Settings",
-        "description": "Settings to customize the calendar.",
-        "data": {
-          "calendar_show_cancelled_lessons": "Calendar - cancelled lessons",
-          "calendar_description": "Calendar - description",
-          "calendar_room": "Calendar - Location",
-          "calendar_show_room_change": "Calendar - Room change",
-          "calendar_replace_name": "Replace event name"
-        },
-        "data_description": {
-          "calendar_show_cancelled_lessons": "Show cancelled lessons in the calendar.",
-          "calendar_description": "Determine what should be in the description of a calendar event.",
-          "calendar_room": "Specify what to display for location.",
-          "calendar_show_room_change": "Show room changes in the calendar.",
-          "calendar_replace_name": "e.g.,\nCancelled: ❌"
-        }
-      },
-      "backend": {
-        "title": "Backend Settings",
-        "description": "Connection and data processing settings.",
-        "data": {
-          "keep_loged_in": "Keep logged in",
-          "generate_json": "Generate JSON",
-          "exclude_data": "Exclude data from request"
-        },
-        "data_description": {
-          "keep_loged_in": "Try to save the session data. (BETA)",
-          "generate_json": "Generate JSON in Sensor Attributes - enable only if needed.",
-          "exclude_data": "This option is set automatically if the user has no rights, to prevent error spamming."
-        }
-      },
-      "edit_notify_service": {
-        "title": "Notify Menu",
-        "description": "add or edit a notify service",
-        "data": {
-          "name": "Name",
-          "entity_id": "Notify Service ID",
-          "target": "Platform-Specific Target Data",
-          "data": "Platform-Specific Notification Data",
-          "template": "Notify Template",
-          "options": "Notify on"
-        },
-        "data_description": {
-          "data": "e.g.,\nnotification_icon: mdi:school-outline",
-          "entity_id": "e.g., notify.discord",
-          "template": "may overwrite data keys"
-        }
-      },
-      "notify_menu": {
-        "title": "Notify Service",
-        "menu_options": {
-          "edit_notify_service": "add notify service",
-          "edit_notify_service_select": "edit notify service",
-          "remove_notify_service": "remove notify service",
-          "test_notify_service": "test notify service"
+          "manual_login": "Manual login",
+          "qr_menu": "Login with QRCode"
         }
       }
-    }
-  },
-  "selector": {
-    "notify_options": {
-      "options": {
-        "homework": "Homework added",
-        "code": "Lesson status changed",
-        "rooms": "Room changed",
-        "teachers": "Teacher changed",
-        "cancelled": "Lesson is cancelled",
-        "subject": "Subject changed",
-        "lstext": "Lesson text changed",
-        "info": "Info text changed"
-      }
-    },
-    "timetable_source": {
-      "options": {
-        "personal": "Personal timetable (recommended)",
-        "student": "Student",
-        "klasse": "Class",
-        "teacher": "Teacher",
-        "subject": "Subject",
-        "room": "Raum"
-      }
-    },
-    "notify_template": {
-      "options": {
-        "message_title": "Message & Title",
-        "message": "Message",
-        "discord": "Discord",
-        "telegram": "Telegram"
-      }
-    },
-    "calendar_description": {
-      "options": {
-        "none": "None",
-        "json": "JSON",
-        "lesson_info": "Lesson Info",
-        "class_name_short": "Class Name (short)",
-        "class_name_long": "Class Name (long)"
-      }
-    }
-  },
-  "issues": {
-    "bad_credentials": {
-      "fix_flow": {
-        "error": {
-          "cannot_connect": "Failed to connect. Please check the host.",
-          "invalid_auth": "Invalid authentication",
-          "bad_credentials": "Invalid password",
-          "unknown": "Unexpected error"
-        },
-        "step": {
-          "confirm": {
-            "description": "Please enter the new password!",
-            "title": "Password has been changed",
-            "data": {
-              "password": "Password"
-            }
-          }
-        }
-      },
-      "title": "Password has been changed"
-    }
-  },
-  "services": {
-    "get_timetable": {
-      "description": "Get the timetable in a given time range.",
-      "fields": {
-        "device_id": {
-          "name": "Device",
-          "description": "Select an instance"
-        },
-        "start": {
-          "name": "Start",
-          "description": "Start of time range"
-        },
-        "end": {
-          "name": "End",
-          "description": "End of time range"
-        },
-        "apply_filter": {
-          "name": "Activate Filter",
-          "description": "Applies the filter from the settings to the results"
-        },
-        "show_cancelled": {
-          "name": "Show Cancelled lessons",
-          "description": "Display cancelled lessons in the result"
-        },
-        "compact_result": {
-          "name": "Simplify Results",
-          "description": "Combine double lessons in the result"
-        },
-        "compact_tolerance_minutes": {
-          "name": "Tolerance for combining (minutes)",
-          "description": "Time tolerance to combine lessons as double lessons. (Only relevant if 'Simplify Results' is activated)"
-        }
-      },
-      "name": "Get Timetable"
-    },
-    "count_lessons": {
-      "description": "Count lessons within a time range.",
-      "fields": {
-        "device_id": {
-          "name": "Device",
-          "description": "Select an instance"
-        },
-        "start": {
-          "name": "Start",
-          "description": "Start of time range"
-        },
-        "end": {
-          "name": "End",
-          "description": "End of time range"
-        },
-        "apply_filter": {
-          "name": "Activate Filter",
-          "description": "Apply the filter from the settings to the results"
-        },
-        "count_cancelled": {
-          "name": "Count Cancelled lessons",
-          "description": "Count cancelled lessons"
-        }
-      },
-      "name": "Count Hours"
-    },
-    "get_schoolyears": {
-      "description": "Get WebUntis schoolyears",
-      "fields": {
-        "device_id": {
-          "name": "Device",
-          "description": "Select an instance"
-        }
-      },
-      "name": "Get Schoolyears"
     }
   },
   "entity": {
-    "sensor": {
-      "next_class": {
-        "name": "Next Lesson"
-      },
-      "next_lesson_to_wake_up": {
-        "name": "Next Lesson to Wake Up"
-      },
-      "today_school_start": {
-        "name": "Today's School Start"
-      },
-      "today_school_end": {
-        "name": "Today's School End"
-      }
-    },
     "calendar": {
-      "homework": {
-        "name": "Homework"
-      },
       "exam": {
         "name": "Exams"
+      },
+      "homework": {
+        "name": "Homework"
       }
     },
     "event": {
@@ -386,13 +127,13 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "code": "Lesson status changed",
-              "rooms": "Room changed",
-              "teachers": "Teacher changed",
               "cancelled": "Lesson cancelled",
+              "code": "Lesson status changed",
+              "info": "Info text changed",
               "lstext": "Lesson text changed",
+              "rooms": "Room changed",
               "subject": "Subject changed",
-              "info": "Info text changed"
+              "teachers": "Teacher changed"
             }
           }
         }
@@ -407,6 +148,265 @@
           }
         }
       }
+    },
+    "sensor": {
+      "next_class": {
+        "name": "Next Lesson"
+      },
+      "next_lesson_to_wake_up": {
+        "name": "Next Lesson to Wake Up"
+      },
+      "today_school_end": {
+        "name": "Today's School End"
+      },
+      "today_school_start": {
+        "name": "Today's School Start"
+      }
+    }
+  },
+  "issues": {
+    "bad_credentials": {
+      "fix_flow": {
+        "error": {
+          "bad_credentials": "Invalid password",
+          "cannot_connect": "Failed to connect. Please check the host.",
+          "invalid_auth": "Invalid authentication",
+          "unknown": "Unexpected error"
+        },
+        "step": {
+          "confirm": {
+            "data": {
+              "password": "Password"
+            },
+            "description": "Please enter the new password!",
+            "title": "Password has been changed"
+          }
+        }
+      },
+      "title": "Password has been changed"
+    }
+  },
+  "options": {
+    "error": {
+      "not_a_dict": "Has to be a dictionary",
+      "notification_invalid": "Notification could not be sent. See logs for more information.",
+      "unknown": "Unexpected error",
+      "unknown_service": "Service ID not found."
+    },
+    "step": {
+      "backend": {
+        "data": {
+          "exclude_data": "Exclude data from request",
+          "generate_json": "Generate JSON",
+          "keep_loged_in": "Keep logged in"
+        },
+        "data_description": {
+          "exclude_data": "This option is set automatically if the user has no rights, to prevent error spamming.",
+          "generate_json": "Generate JSON in Sensor Attributes - enable only if needed.",
+          "keep_loged_in": "Try to save the session data. (BETA)"
+        },
+        "description": "Connection and data processing settings.",
+        "title": "Backend Settings"
+      },
+      "calendar": {
+        "data": {
+          "calendar_description": "Calendar - description",
+          "calendar_replace_name": "Replace event name",
+          "calendar_room": "Calendar - Location",
+          "calendar_show_cancelled_lessons": "Calendar - cancelled lessons",
+          "calendar_show_room_change": "Calendar - Room change"
+        },
+        "data_description": {
+          "calendar_description": "Determine what should be in the description of a calendar event.",
+          "calendar_replace_name": "e.g.,\nCancelled: ❌",
+          "calendar_room": "Specify what to display for location.",
+          "calendar_show_cancelled_lessons": "Show cancelled lessons in the calendar.",
+          "calendar_show_room_change": "Show room changes in the calendar."
+        },
+        "description": "Settings to customize the calendar.",
+        "title": "Calendar Settings"
+      },
+      "edit_notify_service": {
+        "data": {
+          "data": "Platform-Specific Notification Data",
+          "entity_id": "Notify Service ID",
+          "name": "Name",
+          "options": "Notify on",
+          "target": "Platform-Specific Target Data",
+          "template": "Notify Template"
+        },
+        "data_description": {
+          "data": "e.g.,\nnotification_icon: mdi:school-outline",
+          "entity_id": "e.g., notify.discord",
+          "template": "may overwrite data keys"
+        },
+        "description": "add or edit a notify service",
+        "title": "Notify Menu"
+      },
+      "filter": {
+        "data": {
+          "exclude_filter_comparison": "Do not filter lessons for notifications and events",
+          "filter_description": "Filter mode - Description",
+          "filter_klassen": "Filter mode - classes",
+          "filter_mode": "Filter mode",
+          "filter_subjects": "Filter mode - subjects",
+          "invalid_subjects": "No Subjects"
+        },
+        "data_description": {
+          "exclude_filter_comparison": "When enabled the events and notifications are triggered for filtered lessons.",
+          "filter_description": "Hide lessons that contain the following phrases in the description. (Comma-separated list) \nNot affected by blacklist/whitelist.",
+          "filter_mode": "Applies to both subject and class filters",
+          "invalid_subjects": "Allow lessons with no subjects"
+        },
+        "description": "Settings to filter out unwanted lessons.",
+        "title": "Filter Settings"
+      },
+      "init": {
+        "menu_options": {
+          "backend": "Backend",
+          "calendar": "Calendar",
+          "filter": "Filter",
+          "lesson": "Lesson Display",
+          "notify_menu": "Notify Menu"
+        }
+      },
+      "lesson": {
+        "data": {
+          "lesson_add_teacher": "Add Teacher to subject",
+          "lesson_compacting_tolerance": "Max. break time between double lessons",
+          "lesson_long_name": "Long name",
+          "lesson_replace_name": "Replace Lesson name"
+        },
+        "data_description": {
+          "lesson_add_teacher": "Select which subjects should be displayed with the teacher's name.",
+          "lesson_compacting_tolerance": "Identical consecutive lessons will be combined to double lessons if the break time is shorter than this value.",
+          "lesson_replace_name": "e.g.,\nM: Math"
+        },
+        "description": "Settings to customize how the lesson is displayed. \nThis will be applied to the calendar and notifications.",
+        "title": "Lesson Display Settings"
+      },
+      "notify_menu": {
+        "menu_options": {
+          "edit_notify_service": "add notify service",
+          "edit_notify_service_select": "edit notify service",
+          "remove_notify_service": "remove notify service",
+          "test_notify_service": "test notify service"
+        },
+        "title": "Notify Service"
+      }
+    }
+  },
+  "selector": {
+    "calendar_description": {
+      "options": {
+        "class_name_long": "Class Name (long)",
+        "class_name_short": "Class Name (short)",
+        "json": "JSON",
+        "lesson_info": "Lesson Info",
+        "none": "None"
+      }
+    },
+    "notify_options": {
+      "options": {
+        "cancelled": "Lesson is cancelled",
+        "code": "Lesson status changed",
+        "homework": "Homework added",
+        "info": "Info text changed",
+        "lstext": "Lesson text changed",
+        "rooms": "Room changed",
+        "subject": "Subject changed",
+        "teachers": "Teacher changed"
+      }
+    },
+    "notify_template": {
+      "options": {
+        "discord": "Discord",
+        "message": "Message",
+        "message_title": "Message & Title",
+        "telegram": "Telegram"
+      }
+    },
+    "timetable_source": {
+      "options": {
+        "klasse": "Class",
+        "personal": "Personal timetable (recommended)",
+        "room": "Raum",
+        "student": "Student",
+        "subject": "Subject",
+        "teacher": "Teacher"
+      }
+    }
+  },
+  "services": {
+    "count_lessons": {
+      "description": "Count lessons within a time range.",
+      "fields": {
+        "apply_filter": {
+          "description": "Apply the filter from the settings to the results",
+          "name": "Activate Filter"
+        },
+        "count_cancelled": {
+          "description": "Count cancelled lessons",
+          "name": "Count Cancelled lessons"
+        },
+        "device_id": {
+          "description": "Select an instance",
+          "name": "Device"
+        },
+        "end": {
+          "description": "End of time range",
+          "name": "End"
+        },
+        "start": {
+          "description": "Start of time range",
+          "name": "Start"
+        }
+      },
+      "name": "Count Hours"
+    },
+    "get_schoolyears": {
+      "description": "Get WebUntis schoolyears",
+      "fields": {
+        "device_id": {
+          "description": "Select an instance",
+          "name": "Device"
+        }
+      },
+      "name": "Get Schoolyears"
+    },
+    "get_timetable": {
+      "description": "Get the timetable in a given time range.",
+      "fields": {
+        "apply_filter": {
+          "description": "Applies the filter from the settings to the results",
+          "name": "Activate Filter"
+        },
+        "compact_result": {
+          "description": "Combine double lessons in the result",
+          "name": "Simplify Results"
+        },
+        "compact_tolerance_minutes": {
+          "description": "Time tolerance to combine lessons as double lessons. (Only relevant if 'Simplify Results' is activated)",
+          "name": "Tolerance for combining (minutes)"
+        },
+        "device_id": {
+          "description": "Select an instance",
+          "name": "Device"
+        },
+        "end": {
+          "description": "End of time range",
+          "name": "End"
+        },
+        "show_cancelled": {
+          "description": "Display cancelled lessons in the result",
+          "name": "Show Cancelled lessons"
+        },
+        "start": {
+          "description": "Start of time range",
+          "name": "Start"
+        }
+      },
+      "name": "Get Timetable"
     }
   }
 }

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -22,7 +22,7 @@
       "user": {
         "menu_options": {
           "manual_login": "Manual login",
-          "qr_login": "Login with QRCode"
+          "qr_menu": "Login with QRCode"
         },
         "description": "Choose how you want to sign in.",
         "data": {
@@ -34,6 +34,13 @@
         "data_description": {
           "timetable_source_id": "Enter the full name of the student/teacher or the class name",
           "school": "You do not have to enter the full name of the school.\nThe integration will search for schools matching your input."
+        }
+      },
+      "qr_menu": {
+        "description": "Choose how you want to sign in with a QR code.",
+        "menu_options": {
+          "choose_qr_string": "Login with QRCode",
+          "choose_qr_manual": "Login with QRCode (Manual)"
         }
       },
       "manual_login": {
@@ -50,9 +57,14 @@
         "description": "Search for your school or select it from the search results."
       },
       "qr_login": {
-        "description": "Paste the QR payload from the WebUntis app.",
+        "description": "You can find the QRCode in the WebUntis webapp app under **Your Name > Data access**.",
         "data": {
-          "qr_payload": "QRCode payload"
+          "qr_payload": "QRCode payload. You can get it by scanning the QRCode with your phone or by copying the payload",
+          "school": "School",
+          "school_number": "School number",
+          "url": "Server URL",
+          "user": "Username",
+          "key": "Key"
         },
         "data_description": {
           "qr_payload": "The payload usually starts with `untis://`."

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -31,7 +31,7 @@
         },
         "menu_options": {
           "manual_login": "Handmatig inloggen",
-          "qr_login": "Inloggen met QR-code"
+          "qr_menu": "Inloggen met QR-code"
         },
         "description": "Kies hoe je wilt inloggen."
       },
@@ -85,235 +85,246 @@
           "school": "Je hoeft niet de volledige naam van de school in te voeren. De integratie zoekt naar scholen die overeenkomen met je invoer."
         }
       },
+      "qr_menu": {
+        "description": "Kies hoe je wilt inloggen met een QR-code.",
+        "menu_options": {
+          "qr_login": "QR-code inhoud invoeren",
+          "qr_manual": "Handmatig gegevens invoeren"
+        }
+      },
       "qr_login": {
-        "description": "Plak de QR-payload uit de WebUntis-app.",
+        "description": "Je kunt de QR-code vinden in de WebUntis-webapp onder **Je naam > Gegevens toegang**.",
         "data": {
-          "qr_payload": "QR-code payload"
+          "qr_payload": "QR-code inhoud. Je kunt deze verkrijgen door de QR-code te scannen en de inhoud te kopiëren.",
+          "school": "School",
+          "school_number": "Schoolnummer",
+          "url": "Server URL",
+          "user": "Gebruikersnaam",
+          "key": "Key"
         },
         "data_description": {
           "qr_payload": "De payload begint meestal met `untis://`."
         }
       }
-    }
-  },
-  "options": {
-    "error": {
-      "unknown_service": "Service ID not found.",
-      "not_a_dict": "Has to be a dictionary",
-      "notification_invalid": "Notification could not be sent. See logs for more information.",
-      "unknown": "Onverwachte fout"
     },
-    "step": {
-      "init": {
-        "menu_options": {
-          "filter": "Filter",
-          "calendar": "Calendar",
-          "lesson": "Lesson Display",
-          "backend": "Backend",
-          "notify_menu": "Notify Menu"
-        }
+    "options": {
+      "error": {
+        "unknown_service": "Service ID not found.",
+        "not_a_dict": "Has to be a dictionary",
+        "notification_invalid": "Notification could not be sent. See logs for more information.",
+        "unknown": "Onverwachte fout"
       },
-      "filter": {
-        "title": "Filterinstellingen",
-        "description": "Instellingen om ongewenste onderwerpen uit te filteren.",
-        "data": {
-          "filter_mode": "Filter modus",
-          "filter_subjects": "Filtermodus - onderwerpen",
-          "filter_klassen": "Filtermodus - klassen",
-          "filter_description": "Filtermodus - Beschrijving",
-          "invalid_subjects": "No Subjects"
+      "step": {
+        "init": {
+          "menu_options": {
+            "filter": "Filter",
+            "calendar": "Calendar",
+            "lesson": "Lesson Display",
+            "backend": "Backend",
+            "notify_menu": "Notify Menu"
+          }
         },
-        "data_description": {
-          "filter_mode": "Geldt voor zowel onderwerp- als klasfilters",
-          "filter_description": "Verberg lessen die de volgende zinnen in de beschrijving bevatten. (Door komma's gescheiden lijst) \nWordt niet beïnvloed door zwarte lijst/witte lijst.",
-          "invalid_subjects": "Allow lessons with no subjects"
-        }
-      },
-      "lesson": {
-        "title": "Lesson Display Settings",
-        "description": "Settings to customize how the lesson is displayed. \nThis will be applied to the calendar and notifications.",
-        "data": {
-          "lesson_long_name": "Long name",
-          "lesson_replace_name": "Replace Lesson name",
-          "lesson_add_teacher": "Add Teacher to subject",
-          "lesson_compacting_tolerance": "Max. break time between double lessons"
+        "filter": {
+          "title": "Filterinstellingen",
+          "description": "Instellingen om ongewenste onderwerpen uit te filteren.",
+          "data": {
+            "filter_mode": "Filter modus",
+            "filter_subjects": "Filtermodus - onderwerpen",
+            "filter_klassen": "Filtermodus - klassen",
+            "filter_description": "Filtermodus - Beschrijving",
+            "invalid_subjects": "No Subjects"
+          },
+          "data_description": {
+            "filter_mode": "Geldt voor zowel onderwerp- als klasfilters",
+            "filter_description": "Verberg lessen die de volgende zinnen in de beschrijving bevatten. (Door komma's gescheiden lijst) \nWordt niet beïnvloed door zwarte lijst/witte lijst.",
+            "invalid_subjects": "Allow lessons with no subjects"
+          }
         },
-        "data_description": {
-          "lesson_replace_name": "e.g.,\nM: Math",
-          "lesson_add_teacher": "Select which subjects should be displayed with the teacher's name.",
-          "lesson_compacting_tolerance": "Identical consecutive lessons will be combined to double lessons if the break time is shorter than this value."
-        }
-      },
-      "calendar": {
-        "title": "Kalenderinstellingen",
-        "description": "Instellingen om de kalender aan te passen.",
-        "data": {
-          "calendar_show_cancelled_lessons": "Kalender - geannuleerde lessen",
-          "calendar_description": "Calendar - description",
-          "calendar_room": "Calendar - Location",
-          "calendar_show_room_change": "Calendar - Room change",
-          "calendar_replace_name": "Replace event name"
+        "lesson": {
+          "title": "Lesson Display Settings",
+          "description": "Settings to customize how the lesson is displayed. \nThis will be applied to the calendar and notifications.",
+          "data": {
+            "lesson_long_name": "Long name",
+            "lesson_replace_name": "Replace Lesson name",
+            "lesson_add_teacher": "Add Teacher to subject",
+            "lesson_compacting_tolerance": "Max. break time between double lessons"
+          },
+          "data_description": {
+            "lesson_replace_name": "e.g.,\nM: Math",
+            "lesson_add_teacher": "Select which subjects should be displayed with the teacher's name.",
+            "lesson_compacting_tolerance": "Identical consecutive lessons will be combined to double lessons if the break time is shorter than this value."
+          }
         },
-        "data_description": {
-          "calendar_show_cancelled_lessons": "Toon geannuleerde lessen in de kalender.",
-          "calendar_description": "Determine what should be in the description of a calendar event.",
-          "calendar_room": "Specify what to display for location.",
-          "calendar_show_room_change": "Show room changes in the calendar.",
-          "calendar_replace_name": "e.g.,\nCancelled: ❌"
-        }
-      },
-      "backend": {
-        "title": "Instellingen achterzijde",
-        "description": "Instellingen voor verbinding en gegevensverwerking.",
-        "data": {
-          "keep_loged_in": "Ingelogd blijven",
-          "generate_json": "JSON genereren",
-          "exclude_data": "Gegevens uitsluiten van verzoek"
+        "calendar": {
+          "title": "Kalenderinstellingen",
+          "description": "Instellingen om de kalender aan te passen.",
+          "data": {
+            "calendar_show_cancelled_lessons": "Kalender - geannuleerde lessen",
+            "calendar_description": "Calendar - description",
+            "calendar_room": "Calendar - Location",
+            "calendar_show_room_change": "Calendar - Room change",
+            "calendar_replace_name": "Replace event name"
+          },
+          "data_description": {
+            "calendar_show_cancelled_lessons": "Toon geannuleerde lessen in de kalender.",
+            "calendar_description": "Determine what should be in the description of a calendar event.",
+            "calendar_room": "Specify what to display for location.",
+            "calendar_show_room_change": "Show room changes in the calendar.",
+            "calendar_replace_name": "e.g.,\nCancelled: ❌"
+          }
         },
-        "data_description": {
-          "keep_loged_in": "Probeer de sessiegegevens op te slaan. (BETA)",
-          "generate_json": "Genereer JSON in Sensorattributen - alleen inschakelen indien nodig.",
-          "exclude_data": "Deze optie wordt automatisch ingesteld als de gebruiker geen rechten heeft, om het spammen van foutmeldingen te voorkomen."
-        }
-      },
-      "edit_notify_service": {
-        "title": "Notify Menu",
-        "description": "add or edit a notify service",
-        "data": {
-          "name": "Name",
-          "entity_id": "Notify Service ID",
-          "target": "Platform-Specific Target Data",
-          "data": "Platform-Specific Notification Data",
-          "template": "Notify Template",
-          "options": "Notify on"
+        "backend": {
+          "title": "Instellingen achterzijde",
+          "description": "Instellingen voor verbinding en gegevensverwerking.",
+          "data": {
+            "keep_loged_in": "Ingelogd blijven",
+            "generate_json": "JSON genereren",
+            "exclude_data": "Gegevens uitsluiten van verzoek"
+          },
+          "data_description": {
+            "keep_loged_in": "Probeer de sessiegegevens op te slaan. (BETA)",
+            "generate_json": "Genereer JSON in Sensorattributen - alleen inschakelen indien nodig.",
+            "exclude_data": "Deze optie wordt automatisch ingesteld als de gebruiker geen rechten heeft, om het spammen van foutmeldingen te voorkomen."
+          }
         },
-        "data_description": {
-          "data": "e.g.,\nnotification_icon: mdi:school-outline",
-          "entity_id": "e.g., notify.discord",
-          "template": "may overwrite data keys"
-        }
-      },
-      "notify_menu": {
-        "title": "Notify Service",
-        "menu_options": {
-          "edit_notify_service": "add notify service",
-          "edit_notify_service_select": "edit notify service",
-          "remove_notify_service": "remove notify service",
-          "test_notify_service": "test notify service"
-        }
-      }
-    }
-  },
-  "selector": {
-    "notify_options": {
-      "options": {
-        "homework": "Homework added",
-        "code": "Lesson status changed",
-        "rooms": "Room changed",
-        "teachers": "Teacher changed",
-        "cancelled": "Lesson is cancelled"
-      }
-    },
-    "timetable_source": {
-      "options": {
-        "personal": "Personal Timetable",
-        "student": "Student",
-        "klasse": "Klasse",
-        "teacher": "Teacher",
-        "subject": "Subject",
-        "room": "Raum"
-      }
-    },
-    "notify_template": {
-      "options": {
-        "message_title": "Message & Title",
-        "message": "Message",
-        "discord": "Discord"
-      }
-    }
-  },
-  "issues": {
-    "bad_credentials": {
-      "fix_flow": {
-        "error": {
-          "cannot_connect": "Failed to connect. Please check the host.",
-          "invalid_auth": "Invalid authentication",
-          "bad_credentials": "Invalid password",
-          "unknown": "Unexpected error"
+        "edit_notify_service": {
+          "title": "Notify Menu",
+          "description": "add or edit a notify service",
+          "data": {
+            "name": "Name",
+            "entity_id": "Notify Service ID",
+            "target": "Platform-Specific Target Data",
+            "data": "Platform-Specific Notification Data",
+            "template": "Notify Template",
+            "options": "Notify on"
+          },
+          "data_description": {
+            "data": "e.g.,\nnotification_icon: mdi:school-outline",
+            "entity_id": "e.g., notify.discord",
+            "template": "may overwrite data keys"
+          }
         },
-        "step": {
-          "confirm": {
-            "description": "Please enter the new password!",
-            "title": "Password has been changed",
-            "data": {
-              "password": "Password"
-            }
+        "notify_menu": {
+          "title": "Notify Service",
+          "menu_options": {
+            "edit_notify_service": "add notify service",
+            "edit_notify_service_select": "edit notify service",
+            "remove_notify_service": "remove notify service",
+            "test_notify_service": "test notify service"
           }
         }
-      },
-      "title": "Password has been changed"
-    }
-  },
-  "services": {
-    "get_timetable": {
-      "description": "Get the timetable in a given time range.",
-      "fields": {
-        "device_id": {
-          "name": "Device",
-          "description": "Select an instance"
-        },
-        "start": {
-          "name": "Start",
-          "description": "Start of time range"
-        },
-        "end": {
-          "name": "End",
-          "description": "End of time range"
-        },
-        "apply_filter": {
-          "name": "Activate Filter",
-          "description": "Applies the filter from the settings to the results"
-        },
-        "show_cancelled": {
-          "name": "Show Cancelled lessons",
-          "description": "Display cancelled lessons in the result"
-        },
-        "compact_result": {
-          "name": "Simplify Results",
-          "description": "Combine double lessons in the result"
-        },
-        "compact_tolerance_minutes": {
-          "name": "Tolerance for combining (minutes)",
-          "description": "Time tolerance to combine lessons as double lessons. (Only relevant if 'Simplify Results' is activated)"
-        }
-      },
-      "name": "Get Timetable"
+      }
     },
-    "count_lessons": {
-      "description": "Count lessons within a time range.",
-      "fields": {
-        "device_id": {
-          "name": "Device",
-          "description": "Select an instance"
-        },
-        "start": {
-          "name": "Start",
-          "description": "Start of time range"
-        },
-        "end": {
-          "name": "End",
-          "description": "End of time range"
-        },
-        "apply_filter": {
-          "name": "Activate Filter",
-          "description": "Apply the filter from the settings to the results"
-        },
-        "count_cancelled": {
-          "name": "Count Cancelled lessons",
-          "description": "Count cancelled lessons"
+    "selector": {
+      "notify_options": {
+        "options": {
+          "homework": "Homework added",
+          "code": "Lesson status changed",
+          "rooms": "Room changed",
+          "teachers": "Teacher changed",
+          "cancelled": "Lesson is cancelled"
         }
       },
-      "name": "Count Hours"
+      "timetable_source": {
+        "options": {
+          "personal": "Personal Timetable",
+          "student": "Student",
+          "klasse": "Klasse",
+          "teacher": "Teacher",
+          "subject": "Subject",
+          "room": "Raum"
+        }
+      },
+      "notify_template": {
+        "options": {
+          "message_title": "Message & Title",
+          "message": "Message",
+          "discord": "Discord"
+        }
+      }
+    },
+    "issues": {
+      "bad_credentials": {
+        "fix_flow": {
+          "error": {
+            "cannot_connect": "Failed to connect. Please check the host.",
+            "invalid_auth": "Invalid authentication",
+            "bad_credentials": "Invalid password",
+            "unknown": "Unexpected error"
+          },
+          "step": {
+            "confirm": {
+              "description": "Please enter the new password!",
+              "title": "Password has been changed",
+              "data": {
+                "password": "Password"
+              }
+            }
+          }
+        },
+        "title": "Password has been changed"
+      }
+    },
+    "services": {
+      "get_timetable": {
+        "description": "Get the timetable in a given time range.",
+        "fields": {
+          "device_id": {
+            "name": "Device",
+            "description": "Select an instance"
+          },
+          "start": {
+            "name": "Start",
+            "description": "Start of time range"
+          },
+          "end": {
+            "name": "End",
+            "description": "End of time range"
+          },
+          "apply_filter": {
+            "name": "Activate Filter",
+            "description": "Applies the filter from the settings to the results"
+          },
+          "show_cancelled": {
+            "name": "Show Cancelled lessons",
+            "description": "Display cancelled lessons in the result"
+          },
+          "compact_result": {
+            "name": "Simplify Results",
+            "description": "Combine double lessons in the result"
+          },
+          "compact_tolerance_minutes": {
+            "name": "Tolerance for combining (minutes)",
+            "description": "Time tolerance to combine lessons as double lessons. (Only relevant if 'Simplify Results' is activated)"
+          }
+        },
+        "name": "Get Timetable"
+      },
+      "count_lessons": {
+        "description": "Count lessons within a time range.",
+        "fields": {
+          "device_id": {
+            "name": "Device",
+            "description": "Select an instance"
+          },
+          "start": {
+            "name": "Start",
+            "description": "Start of time range"
+          },
+          "end": {
+            "name": "End",
+            "description": "End of time range"
+          },
+          "apply_filter": {
+            "name": "Activate Filter",
+            "description": "Apply the filter from the settings to the results"
+          },
+          "count_cancelled": {
+            "name": "Count Cancelled lessons",
+            "description": "Count cancelled lessons"
+          }
+        },
+        "name": "Count Hours"
+      }
     }
   }
-}

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -14,7 +14,8 @@
       "class_not_found": "Klasse niet gevonden. Controleer de klasse of kies een andere bron.",
       "no_rights_for_timetable": "No rights for timetable. Choose another name or source.",
       "no_school_year": "You can only configurate via Class if there is a active schoolyear.",
-      "unknown": "Unexpected error. View Logs for more infos."
+      "unknown": "Unexpected error. View Logs for more infos.",
+      "invalid_qr_format": "Ongeldige QR-code payload"
     },
     "step": {
       "user": {
@@ -27,7 +28,12 @@
         "data_description": {
           "timetable_source_id": "Enter the full name of the student/teacher or the class name",
           "school": "Je hoeft niet de volledige naam van de school in te voeren. De integratie zoekt naar scholen die overeenkomen met je invoer."
-        }
+        },
+        "menu_options": {
+          "manual_login": "Handmatig inloggen",
+          "qr_login": "Inloggen met QR-code"
+        },
+        "description": "Kies hoe je wilt inloggen."
       },
       "auth": {
         "description": "Voer je Untis-gegevens in voor **{school_name}**.",
@@ -64,6 +70,28 @@
       "reconfigure": {
         "data": {
           "password": "Wachtwoord"
+        }
+      },
+      "manual_login": {
+        "description": "Zoek je school of selecteer deze uit de zoekresultaten.",
+        "data": {
+          "school": "Schoolnaam of zoekterm",
+          "timetable_source": "Tijdschema bron",
+          "timetable_source_id": "Full name/Class",
+          "school_choice": "Kies je school:"
+        },
+        "data_description": {
+          "timetable_source_id": "Enter the full name of the student/teacher or the class name",
+          "school": "Je hoeft niet de volledige naam van de school in te voeren. De integratie zoekt naar scholen die overeenkomen met je invoer."
+        }
+      },
+      "qr_login": {
+        "description": "Plak de QR-payload uit de WebUntis-app.",
+        "data": {
+          "qr_payload": "QR-code payload"
+        },
+        "data_description": {
+          "qr_payload": "De payload begint meestal met `untis://`."
         }
       }
     }

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -281,14 +281,14 @@
       "qr_login": {
         "data": {
           "key": "Key",
-          "qr_payload": "QR-code inhoud. Je kunt deze verkrijgen door de QR-code te scannen en de inhoud te kopiëren.",
+          "qr_payload": "QR-code inhoud",
           "school": "School",
           "school_number": "Schoolnummer",
           "url": "Server URL",
           "user": "Gebruikersnaam"
         },
         "data_description": {
-          "qr_payload": "De payload begint meestal met `untis://`."
+          "qr_payload": "De payload begint meestal met `untis://`. Je kunt deze verkrijgen door de QR-code te scannen en de inhoud te kopiëren."
         },
         "description": "Je kunt de QR-code vinden in de WebUntis-webapp onder **Je naam > Gegevens toegang**."
       },

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -4,86 +4,293 @@
       "already_configured": "Het apparaat is al geconfigureerd"
     },
     "error": {
-      "cannot_connect": "Kan geen verbinding maken. Controleer de host.",
-      "invalid_auth": "Ongeldige verificatie",
       "bad_credentials": "Ongeldige gebruikersnaam en/of wachtwoord",
-      "school_not_found": "Er zijn geen scholen gevonden die overeenkomen met je invoer. Controleer de naam of probeer een andere zoekterm.",
-      "name_split_error": "Ongeldige naam. Probeer \"voornaam, achternaam\".",
-      "student_not_found": "Student niet gevonden. Controleer de naam of kies een andere bron.",
-      "teacher_not_found": "Leraar niet gevonden. Controleer de naam of kies een andere bron.",
+      "cannot_connect": "Kan geen verbinding maken. Controleer de host.",
       "class_not_found": "Klasse niet gevonden. Controleer de klasse of kies een andere bron.",
+      "invalid_auth": "Ongeldige verificatie",
+      "invalid_qr_format": "Ongeldige QR-code payload",
+      "name_split_error": "Ongeldige naam. Probeer \"voornaam, achternaam\".",
       "no_rights_for_timetable": "No rights for timetable. Choose another name or source.",
       "no_school_year": "You can only configurate via Class if there is a active schoolyear.",
-      "unknown": "Unexpected error. View Logs for more infos.",
-      "invalid_qr_format": "Ongeldige QR-code payload"
+      "school_not_found": "Er zijn geen scholen gevonden die overeenkomen met je invoer. Controleer de naam of probeer een andere zoekterm.",
+      "student_not_found": "Student niet gevonden. Controleer de naam of kies een andere bron.",
+      "teacher_not_found": "Leraar niet gevonden. Controleer de naam of kies een andere bron.",
+      "unknown": "Unexpected error. View Logs for more infos."
     },
-    "step": {
-      "user": {
-        "data": {
-          "school": "Schoolnaam of zoekterm",
-          "timetable_source": "Tijdschema bron",
-          "timetable_source_id": "Full name/Class",
-          "school_choice": "Kies je school:"
+    "issues": {
+      "bad_credentials": {
+        "fix_flow": {
+          "error": {
+            "bad_credentials": "Invalid password",
+            "cannot_connect": "Failed to connect. Please check the host.",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+          },
+          "step": {
+            "confirm": {
+              "data": {
+                "password": "Password"
+              },
+              "description": "Please enter the new password!",
+              "title": "Password has been changed"
+            }
+          }
         },
-        "data_description": {
-          "timetable_source_id": "Enter the full name of the student/teacher or the class name",
-          "school": "Je hoeft niet de volledige naam van de school in te voeren. De integratie zoekt naar scholen die overeenkomen met je invoer."
-        },
-        "menu_options": {
-          "manual_login": "Handmatig inloggen",
-          "qr_menu": "Inloggen met QR-code"
-        },
-        "description": "Kies hoe je wilt inloggen."
+        "title": "Password has been changed"
+      }
+    },
+    "options": {
+      "error": {
+        "not_a_dict": "Has to be a dictionary",
+        "notification_invalid": "Notification could not be sent. See logs for more information.",
+        "unknown": "Onverwachte fout",
+        "unknown_service": "Service ID not found."
       },
-      "auth": {
-        "description": "Voer je Untis-gegevens in voor **{school_name}**.",
-        "data": {
-          "username": "Gebruikersnaam",
-          "password": "Wachtwoord"
+      "step": {
+        "backend": {
+          "data": {
+            "exclude_data": "Gegevens uitsluiten van verzoek",
+            "generate_json": "JSON genereren",
+            "keep_loged_in": "Ingelogd blijven"
+          },
+          "data_description": {
+            "exclude_data": "Deze optie wordt automatisch ingesteld als de gebruiker geen rechten heeft, om het spammen van foutmeldingen te voorkomen.",
+            "generate_json": "Genereer JSON in Sensorattributen - alleen inschakelen indien nodig.",
+            "keep_loged_in": "Probeer de sessiegegevens op te slaan. (BETA)"
+          },
+          "description": "Instellingen voor verbinding en gegevensverwerking.",
+          "title": "Instellingen achterzijde"
+        },
+        "calendar": {
+          "data": {
+            "calendar_description": "Calendar - description",
+            "calendar_replace_name": "Replace event name",
+            "calendar_room": "Calendar - Location",
+            "calendar_show_cancelled_lessons": "Kalender - geannuleerde lessen",
+            "calendar_show_room_change": "Calendar - Room change"
+          },
+          "data_description": {
+            "calendar_description": "Determine what should be in the description of a calendar event.",
+            "calendar_replace_name": "e.g.,\nCancelled: ❌",
+            "calendar_room": "Specify what to display for location.",
+            "calendar_show_cancelled_lessons": "Toon geannuleerde lessen in de kalender.",
+            "calendar_show_room_change": "Show room changes in the calendar."
+          },
+          "description": "Instellingen om de kalender aan te passen.",
+          "title": "Kalenderinstellingen"
+        },
+        "edit_notify_service": {
+          "data": {
+            "data": "Platform-Specific Notification Data",
+            "entity_id": "Notify Service ID",
+            "name": "Name",
+            "options": "Notify on",
+            "target": "Platform-Specific Target Data",
+            "template": "Notify Template"
+          },
+          "data_description": {
+            "data": "e.g.,\nnotification_icon: mdi:school-outline",
+            "entity_id": "e.g., notify.discord",
+            "template": "may overwrite data keys"
+          },
+          "description": "add or edit a notify service",
+          "title": "Notify Menu"
+        },
+        "filter": {
+          "data": {
+            "filter_description": "Filtermodus - Beschrijving",
+            "filter_klassen": "Filtermodus - klassen",
+            "filter_mode": "Filter modus",
+            "filter_subjects": "Filtermodus - onderwerpen",
+            "invalid_subjects": "No Subjects"
+          },
+          "data_description": {
+            "filter_description": "Verberg lessen die de volgende zinnen in de beschrijving bevatten. (Door komma's gescheiden lijst) \nWordt niet beïnvloed door zwarte lijst/witte lijst.",
+            "filter_mode": "Geldt voor zowel onderwerp- als klasfilters",
+            "invalid_subjects": "Allow lessons with no subjects"
+          },
+          "description": "Instellingen om ongewenste onderwerpen uit te filteren.",
+          "title": "Filterinstellingen"
+        },
+        "init": {
+          "menu_options": {
+            "backend": "Backend",
+            "calendar": "Calendar",
+            "filter": "Filter",
+            "lesson": "Lesson Display",
+            "notify_menu": "Notify Menu"
+          }
+        },
+        "lesson": {
+          "data": {
+            "lesson_add_teacher": "Add Teacher to subject",
+            "lesson_compacting_tolerance": "Max. break time between double lessons",
+            "lesson_long_name": "Long name",
+            "lesson_replace_name": "Replace Lesson name"
+          },
+          "data_description": {
+            "lesson_add_teacher": "Select which subjects should be displayed with the teacher's name.",
+            "lesson_compacting_tolerance": "Identical consecutive lessons will be combined to double lessons if the break time is shorter than this value.",
+            "lesson_replace_name": "e.g.,\nM: Math"
+          },
+          "description": "Settings to customize how the lesson is displayed. \nThis will be applied to the calendar and notifications.",
+          "title": "Lesson Display Settings"
+        },
+        "notify_menu": {
+          "menu_options": {
+            "edit_notify_service": "add notify service",
+            "edit_notify_service_select": "edit notify service",
+            "remove_notify_service": "remove notify service",
+            "test_notify_service": "test notify service"
+          },
+          "title": "Notify Service"
+        }
+      }
+    },
+    "selector": {
+      "notify_options": {
+        "options": {
+          "cancelled": "Lesson is cancelled",
+          "code": "Lesson status changed",
+          "homework": "Homework added",
+          "rooms": "Room changed",
+          "teachers": "Teacher changed"
+        }
+      },
+      "notify_template": {
+        "options": {
+          "discord": "Discord",
+          "message": "Message",
+          "message_title": "Message & Title"
         }
       },
       "timetable_source": {
-        "data": {
-          "timetable_source": "Selecteer de bron van het rooster:"
+        "options": {
+          "klasse": "Klasse",
+          "personal": "Personal Timetable",
+          "room": "Raum",
+          "student": "Student",
+          "subject": "Subject",
+          "teacher": "Teacher"
         }
+      }
+    },
+    "services": {
+      "count_lessons": {
+        "description": "Count lessons within a time range.",
+        "fields": {
+          "apply_filter": {
+            "description": "Apply the filter from the settings to the results",
+            "name": "Activate Filter"
+          },
+          "count_cancelled": {
+            "description": "Count cancelled lessons",
+            "name": "Count Cancelled lessons"
+          },
+          "device_id": {
+            "description": "Select an instance",
+            "name": "Device"
+          },
+          "end": {
+            "description": "End of time range",
+            "name": "End"
+          },
+          "start": {
+            "description": "Start of time range",
+            "name": "Start"
+          }
+        },
+        "name": "Count Hours"
       },
-      "pick_student": {
-        "description": "Enter a Student Name",
+      "get_timetable": {
+        "description": "Get the timetable in a given time range.",
+        "fields": {
+          "apply_filter": {
+            "description": "Applies the filter from the settings to the results",
+            "name": "Activate Filter"
+          },
+          "compact_result": {
+            "description": "Combine double lessons in the result",
+            "name": "Simplify Results"
+          },
+          "compact_tolerance_minutes": {
+            "description": "Time tolerance to combine lessons as double lessons. (Only relevant if 'Simplify Results' is activated)",
+            "name": "Tolerance for combining (minutes)"
+          },
+          "device_id": {
+            "description": "Select an instance",
+            "name": "Device"
+          },
+          "end": {
+            "description": "End of time range",
+            "name": "End"
+          },
+          "show_cancelled": {
+            "description": "Display cancelled lessons in the result",
+            "name": "Show Cancelled lessons"
+          },
+          "start": {
+            "description": "Start of time range",
+            "name": "Start"
+          }
+        },
+        "name": "Get Timetable"
+      }
+    },
+    "step": {
+      "auth": {
         "data": {
-          "surname": "Surname",
-          "fore_name": "Fore Name"
-        }
-      },
-      "pick_teacher": {
-        "description": "Enter a Teacher Name",
-        "data": {
-          "surname": "Surname",
-          "fore_name": "Fore Name"
-        }
-      },
-      "pick_klasse": {
-        "description": "Enter class Name",
-        "data": {
-          "klasse": "Class"
-        }
-      },
-      "reconfigure": {
-        "data": {
-          "password": "Wachtwoord"
-        }
+          "password": "Wachtwoord",
+          "username": "Gebruikersnaam"
+        },
+        "description": "Voer je Untis-gegevens in voor **{school_name}**."
       },
       "manual_login": {
-        "description": "Zoek je school of selecteer deze uit de zoekresultaten.",
         "data": {
           "school": "Schoolnaam of zoekterm",
+          "school_choice": "Kies je school:",
           "timetable_source": "Tijdschema bron",
-          "timetable_source_id": "Full name/Class",
-          "school_choice": "Kies je school:"
+          "timetable_source_id": "Full name/Class"
         },
         "data_description": {
-          "timetable_source_id": "Enter the full name of the student/teacher or the class name",
-          "school": "Je hoeft niet de volledige naam van de school in te voeren. De integratie zoekt naar scholen die overeenkomen met je invoer."
-        }
+          "school": "Je hoeft niet de volledige naam van de school in te voeren. De integratie zoekt naar scholen die overeenkomen met je invoer.",
+          "timetable_source_id": "Enter the full name of the student/teacher or the class name"
+        },
+        "description": "Zoek je school of selecteer deze uit de zoekresultaten."
+      },
+      "pick_klasse": {
+        "data": {
+          "klasse": "Class"
+        },
+        "description": "Enter class Name"
+      },
+      "pick_student": {
+        "data": {
+          "fore_name": "Fore Name",
+          "surname": "Surname"
+        },
+        "description": "Enter a Student Name"
+      },
+      "pick_teacher": {
+        "data": {
+          "fore_name": "Fore Name",
+          "surname": "Surname"
+        },
+        "description": "Enter a Teacher Name"
+      },
+      "qr_login": {
+        "data": {
+          "key": "Key",
+          "qr_payload": "QR-code inhoud. Je kunt deze verkrijgen door de QR-code te scannen en de inhoud te kopiëren.",
+          "school": "School",
+          "school_number": "Schoolnummer",
+          "url": "Server URL",
+          "user": "Gebruikersnaam"
+        },
+        "data_description": {
+          "qr_payload": "De payload begint meestal met `untis://`."
+        },
+        "description": "Je kunt de QR-code vinden in de WebUntis-webapp onder **Je naam > Gegevens toegang**."
       },
       "qr_menu": {
         "description": "Kies hoe je wilt inloggen met een QR-code.",
@@ -92,239 +299,33 @@
           "qr_manual": "Handmatig gegevens invoeren"
         }
       },
-      "qr_login": {
-        "description": "Je kunt de QR-code vinden in de WebUntis-webapp onder **Je naam > Gegevens toegang**.",
+      "reconfigure": {
         "data": {
-          "qr_payload": "QR-code inhoud. Je kunt deze verkrijgen door de QR-code te scannen en de inhoud te kopiëren.",
-          "school": "School",
-          "school_number": "Schoolnummer",
-          "url": "Server URL",
-          "user": "Gebruikersnaam",
-          "key": "Key"
-        },
-        "data_description": {
-          "qr_payload": "De payload begint meestal met `untis://`."
-        }
-      }
-    },
-    "options": {
-      "error": {
-        "unknown_service": "Service ID not found.",
-        "not_a_dict": "Has to be a dictionary",
-        "notification_invalid": "Notification could not be sent. See logs for more information.",
-        "unknown": "Onverwachte fout"
-      },
-      "step": {
-        "init": {
-          "menu_options": {
-            "filter": "Filter",
-            "calendar": "Calendar",
-            "lesson": "Lesson Display",
-            "backend": "Backend",
-            "notify_menu": "Notify Menu"
-          }
-        },
-        "filter": {
-          "title": "Filterinstellingen",
-          "description": "Instellingen om ongewenste onderwerpen uit te filteren.",
-          "data": {
-            "filter_mode": "Filter modus",
-            "filter_subjects": "Filtermodus - onderwerpen",
-            "filter_klassen": "Filtermodus - klassen",
-            "filter_description": "Filtermodus - Beschrijving",
-            "invalid_subjects": "No Subjects"
-          },
-          "data_description": {
-            "filter_mode": "Geldt voor zowel onderwerp- als klasfilters",
-            "filter_description": "Verberg lessen die de volgende zinnen in de beschrijving bevatten. (Door komma's gescheiden lijst) \nWordt niet beïnvloed door zwarte lijst/witte lijst.",
-            "invalid_subjects": "Allow lessons with no subjects"
-          }
-        },
-        "lesson": {
-          "title": "Lesson Display Settings",
-          "description": "Settings to customize how the lesson is displayed. \nThis will be applied to the calendar and notifications.",
-          "data": {
-            "lesson_long_name": "Long name",
-            "lesson_replace_name": "Replace Lesson name",
-            "lesson_add_teacher": "Add Teacher to subject",
-            "lesson_compacting_tolerance": "Max. break time between double lessons"
-          },
-          "data_description": {
-            "lesson_replace_name": "e.g.,\nM: Math",
-            "lesson_add_teacher": "Select which subjects should be displayed with the teacher's name.",
-            "lesson_compacting_tolerance": "Identical consecutive lessons will be combined to double lessons if the break time is shorter than this value."
-          }
-        },
-        "calendar": {
-          "title": "Kalenderinstellingen",
-          "description": "Instellingen om de kalender aan te passen.",
-          "data": {
-            "calendar_show_cancelled_lessons": "Kalender - geannuleerde lessen",
-            "calendar_description": "Calendar - description",
-            "calendar_room": "Calendar - Location",
-            "calendar_show_room_change": "Calendar - Room change",
-            "calendar_replace_name": "Replace event name"
-          },
-          "data_description": {
-            "calendar_show_cancelled_lessons": "Toon geannuleerde lessen in de kalender.",
-            "calendar_description": "Determine what should be in the description of a calendar event.",
-            "calendar_room": "Specify what to display for location.",
-            "calendar_show_room_change": "Show room changes in the calendar.",
-            "calendar_replace_name": "e.g.,\nCancelled: ❌"
-          }
-        },
-        "backend": {
-          "title": "Instellingen achterzijde",
-          "description": "Instellingen voor verbinding en gegevensverwerking.",
-          "data": {
-            "keep_loged_in": "Ingelogd blijven",
-            "generate_json": "JSON genereren",
-            "exclude_data": "Gegevens uitsluiten van verzoek"
-          },
-          "data_description": {
-            "keep_loged_in": "Probeer de sessiegegevens op te slaan. (BETA)",
-            "generate_json": "Genereer JSON in Sensorattributen - alleen inschakelen indien nodig.",
-            "exclude_data": "Deze optie wordt automatisch ingesteld als de gebruiker geen rechten heeft, om het spammen van foutmeldingen te voorkomen."
-          }
-        },
-        "edit_notify_service": {
-          "title": "Notify Menu",
-          "description": "add or edit a notify service",
-          "data": {
-            "name": "Name",
-            "entity_id": "Notify Service ID",
-            "target": "Platform-Specific Target Data",
-            "data": "Platform-Specific Notification Data",
-            "template": "Notify Template",
-            "options": "Notify on"
-          },
-          "data_description": {
-            "data": "e.g.,\nnotification_icon: mdi:school-outline",
-            "entity_id": "e.g., notify.discord",
-            "template": "may overwrite data keys"
-          }
-        },
-        "notify_menu": {
-          "title": "Notify Service",
-          "menu_options": {
-            "edit_notify_service": "add notify service",
-            "edit_notify_service_select": "edit notify service",
-            "remove_notify_service": "remove notify service",
-            "test_notify_service": "test notify service"
-          }
-        }
-      }
-    },
-    "selector": {
-      "notify_options": {
-        "options": {
-          "homework": "Homework added",
-          "code": "Lesson status changed",
-          "rooms": "Room changed",
-          "teachers": "Teacher changed",
-          "cancelled": "Lesson is cancelled"
+          "password": "Wachtwoord"
         }
       },
       "timetable_source": {
-        "options": {
-          "personal": "Personal Timetable",
-          "student": "Student",
-          "klasse": "Klasse",
-          "teacher": "Teacher",
-          "subject": "Subject",
-          "room": "Raum"
+        "data": {
+          "timetable_source": "Selecteer de bron van het rooster:"
         }
       },
-      "notify_template": {
-        "options": {
-          "message_title": "Message & Title",
-          "message": "Message",
-          "discord": "Discord"
+      "user": {
+        "data": {
+          "school": "Schoolnaam of zoekterm",
+          "school_choice": "Kies je school:",
+          "timetable_source": "Tijdschema bron",
+          "timetable_source_id": "Full name/Class"
+        },
+        "data_description": {
+          "school": "Je hoeft niet de volledige naam van de school in te voeren. De integratie zoekt naar scholen die overeenkomen met je invoer.",
+          "timetable_source_id": "Enter the full name of the student/teacher or the class name"
+        },
+        "description": "Kies hoe je wilt inloggen.",
+        "menu_options": {
+          "manual_login": "Handmatig inloggen",
+          "qr_menu": "Inloggen met QR-code"
         }
-      }
-    },
-    "issues": {
-      "bad_credentials": {
-        "fix_flow": {
-          "error": {
-            "cannot_connect": "Failed to connect. Please check the host.",
-            "invalid_auth": "Invalid authentication",
-            "bad_credentials": "Invalid password",
-            "unknown": "Unexpected error"
-          },
-          "step": {
-            "confirm": {
-              "description": "Please enter the new password!",
-              "title": "Password has been changed",
-              "data": {
-                "password": "Password"
-              }
-            }
-          }
-        },
-        "title": "Password has been changed"
-      }
-    },
-    "services": {
-      "get_timetable": {
-        "description": "Get the timetable in a given time range.",
-        "fields": {
-          "device_id": {
-            "name": "Device",
-            "description": "Select an instance"
-          },
-          "start": {
-            "name": "Start",
-            "description": "Start of time range"
-          },
-          "end": {
-            "name": "End",
-            "description": "End of time range"
-          },
-          "apply_filter": {
-            "name": "Activate Filter",
-            "description": "Applies the filter from the settings to the results"
-          },
-          "show_cancelled": {
-            "name": "Show Cancelled lessons",
-            "description": "Display cancelled lessons in the result"
-          },
-          "compact_result": {
-            "name": "Simplify Results",
-            "description": "Combine double lessons in the result"
-          },
-          "compact_tolerance_minutes": {
-            "name": "Tolerance for combining (minutes)",
-            "description": "Time tolerance to combine lessons as double lessons. (Only relevant if 'Simplify Results' is activated)"
-          }
-        },
-        "name": "Get Timetable"
-      },
-      "count_lessons": {
-        "description": "Count lessons within a time range.",
-        "fields": {
-          "device_id": {
-            "name": "Device",
-            "description": "Select an instance"
-          },
-          "start": {
-            "name": "Start",
-            "description": "Start of time range"
-          },
-          "end": {
-            "name": "End",
-            "description": "End of time range"
-          },
-          "apply_filter": {
-            "name": "Activate Filter",
-            "description": "Apply the filter from the settings to the results"
-          },
-          "count_cancelled": {
-            "name": "Count Cancelled lessons",
-            "description": "Count cancelled lessons"
-          }
-        },
-        "name": "Count Hours"
       }
     }
   }
+}

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -295,8 +295,8 @@
       "qr_menu": {
         "description": "Kies hoe je wilt inloggen met een QR-code.",
         "menu_options": {
-          "qr_login": "QR-code inhoud invoeren",
-          "qr_manual": "Handmatig gegevens invoeren"
+          "choose_qr_string": "QR-code inhoud invoeren",
+          "choose_qr_manual": "Handmatig gegevens invoeren"
         }
       },
       "reconfigure": {

--- a/custom_components/webuntis/utils/qrLogin.py
+++ b/custom_components/webuntis/utils/qrLogin.py
@@ -69,25 +69,37 @@ async def async_qr_login(
 ) -> tuple[dict[str, Any], str]:
     """Authenticate via QR credentials and return user payload and JSESSIONID."""
     method = "getUserData2017"
+
+    # 1. TOTP generieren
+    totp = pyotp.TOTP(credentials.key)
+    otp_value = totp.now()
+
     body = {
         "id": "ha-webuntis-qr",
         "method": method,
         "params": [
             {
-                "auth": _qr_auth_block(credentials),
+                "auth": {
+                    "user": credentials.user,
+                    "otp": int(otp_value) if otp_value.isdigit() else otp_value,
+                    "clientTime": int(time.time() * 1000),
+                },
                 "deviceOs": "AND",
                 "deviceOsVersion": "13",
             }
         ],
         "jsonrpc": "2.0",
     }
+
     headers = {
         "Content-Type": "application/json",
         "User-Agent": QR_USER_AGENT,
     }
 
+    url = _qr_endpoint(credentials, method)
+
     async with client_session.post(
-        _qr_endpoint(credentials, method),
+        url,
         json=body,
         headers=headers,
         timeout=aiohttp.ClientTimeout(total=20),
@@ -95,25 +107,45 @@ async def async_qr_login(
         response.raise_for_status()
         data = await response.json(content_type=None)
 
+        # Prüfen, ob WebUntis ein explizites Error-Objekt geschickt hat
         error = data.get("error")
         if error:
             message = error.get("message", error) if isinstance(error, dict) else error
-            raise errors.NotLoggedInError(f"WebUntis error: {message}")
+            code = error.get("code", "") if isinstance(error, dict) else ""
+            raise errors.NotLoggedInError(f"WebUntis RPC Error ({code}): {message}")
 
         result = data.get("result")
         user_data = result if isinstance(result, dict) else {}
 
-        jsessionid_cookie = response.cookies.get("JSESSIONID")
-        jsessionid = jsessionid_cookie.value if jsessionid_cookie else None
+        # --- JSESSIONID EXTRAKTION (3-Wege-Fallback) ---
+        jsessionid = None
 
-        # 2. read ID from the JSON body as fallback
+        # Weg A: Direkte Abfrage aus den Response-Cookies
+        if "JSESSIONID" in response.cookies:
+            jsessionid = response.cookies["JSESSIONID"].value
+
+        # Weg B: Aus dem CookieJar der ClientSession suchen
+        if not jsessionid and client_session.cookie_jar:
+            for cookie in client_session.cookie_jar:
+                if cookie.key == "JSESSIONID":
+                    jsessionid = cookie.value
+                    break
+
+        # Weg C: Aus den rohen 'Set-Cookie' Headern parsen
+        if not jsessionid:
+            set_cookie_headers = response.headers.getall("Set-Cookie", [])
+            for header in set_cookie_headers:
+                if "JSESSIONID=" in header:
+                    jsessionid = header.split("JSESSIONID=")[1].split(";")[0].strip()
+                    break
+
+        # Weg D: Fallback aus dem JSON-Body
         if not jsessionid and isinstance(user_data, dict):
             jsessionid = user_data.get("sessionId")
 
         if not jsessionid:
             raise errors.NotLoggedInError(
-                f"Could not find JSESSIONID or sessionId in QR login response. "
-                f"Response data: {data}"
+                f"WebUntis lehnte Session ab oder sendete keine JSESSIONID. Response: {data}"
             )
 
         return user_data, jsessionid

--- a/custom_components/webuntis/utils/qrLogin.py
+++ b/custom_components/webuntis/utils/qrLogin.py
@@ -100,15 +100,23 @@ async def async_qr_login(
             message = error.get("message", error) if isinstance(error, dict) else error
             raise errors.NotLoggedInError(f"WebUntis error: {message}")
 
-        jsessionid = response.cookies.get("JSESSIONID")
-        if jsessionid is None:
-            raise errors.NotLoggedInError(
-                "Could not find JSESSIONID in QR login response"
-            )
-
         result = data.get("result")
         user_data = result if isinstance(result, dict) else {}
-        return user_data, jsessionid.value
+
+        jsessionid_cookie = response.cookies.get("JSESSIONID")
+        jsessionid = jsessionid_cookie.value if jsessionid_cookie else None
+
+        # 2. read ID from the JSON body as fallback
+        if not jsessionid and isinstance(user_data, dict):
+            jsessionid = user_data.get("sessionId")
+
+        if not jsessionid:
+            raise errors.NotLoggedInError(
+                f"Could not find JSESSIONID or sessionId in QR login response. "
+                f"Response data: {data}"
+            )
+
+        return user_data, jsessionid
 
 
 def _normalize_server_url(server: str) -> str:

--- a/custom_components/webuntis/utils/qrLogin.py
+++ b/custom_components/webuntis/utils/qrLogin.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from urllib.parse import parse_qs, urlparse
 
+import time
+from typing import Any
+
+import aiohttp
+import pyotp
+from webuntis import errors
+
 
 @dataclass(frozen=True)
 class QrData:
@@ -17,6 +24,92 @@ class QrData:
 
 qrData = QrData
 
+QR_USER_AGENT = "UntisMobileAndroid"
+QR_API_VERSION = "i3.2"
+
+
+def extract_login_result(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract fields expected by webuntis.Session.login_result from QR user_data."""
+    login_result = {}
+
+    type_map = {
+        "KLASSE": 1,
+        "TEACHER": 2,
+        "SUBJECT": 3,
+        "ROOM": 4,
+        "STUDENT": 5,
+    }
+
+    user_data = data.get("userData", {}) if isinstance(data, dict) else {}
+
+    if "elemId" in user_data:
+        login_result["personId"] = user_data["elemId"]
+
+    if "elemType" in user_data:
+        elem_type = user_data["elemType"]
+        if isinstance(elem_type, str):
+            login_result["personType"] = type_map.get(elem_type.upper(), 5)
+        else:
+            login_result["personType"] = elem_type
+
+    if user_data.get("klassenIds"):
+        login_result["klasseId"] = user_data["klassenIds"][0]
+
+    # Fallback for default keys
+    for key in ("personType", "personId", "klasseId"):
+        if key in data and key not in login_result:
+            login_result[key] = data[key]
+
+    return login_result
+
+
+async def async_qr_login(
+    credentials: QrData,
+    client_session: aiohttp.ClientSession,
+) -> tuple[dict[str, Any], str]:
+    """Authenticate via QR credentials and return user payload and JSESSIONID."""
+    method = "getUserData2017"
+    body = {
+        "id": "ha-webuntis-qr",
+        "method": method,
+        "params": [
+            {
+                "auth": _qr_auth_block(credentials),
+                "deviceOs": "AND",
+                "deviceOsVersion": "13",
+            }
+        ],
+        "jsonrpc": "2.0",
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": QR_USER_AGENT,
+    }
+
+    async with client_session.post(
+        _qr_endpoint(credentials, method),
+        json=body,
+        headers=headers,
+        timeout=aiohttp.ClientTimeout(total=20),
+    ) as response:
+        response.raise_for_status()
+        data = await response.json(content_type=None)
+
+        error = data.get("error")
+        if error:
+            message = error.get("message", error) if isinstance(error, dict) else error
+            raise errors.NotLoggedInError(f"WebUntis error: {message}")
+
+        jsessionid = response.cookies.get("JSESSIONID")
+        if jsessionid is None:
+            raise errors.NotLoggedInError(
+                "Could not find JSESSIONID in QR login response"
+            )
+
+        result = data.get("result")
+        user_data = result if isinstance(result, dict) else {}
+        return user_data, jsessionid.value
+
 
 def _normalize_server_url(server: str) -> str:
     parsed = urlparse(server if "://" in server else f"https://{server}")
@@ -24,6 +117,23 @@ def _normalize_server_url(server: str) -> str:
     if not host:
         raise ValueError("QR payload does not contain a valid server")
     return host
+
+
+def _qr_endpoint(credentials: QrData, method: str) -> str:
+    """Build the API endpoint URL for QR login."""
+    return (
+        f"https://{credentials.server}/WebUntis/jsonrpc_intern.do"
+        f"?m={method}&school={credentials.school}&v={QR_API_VERSION}"
+    )
+
+
+def _qr_auth_block(credentials: QrData) -> dict[str, Any]:
+    """Generate auth block with TOTP for QR login."""
+    return {
+        "user": credentials.user,
+        "otp": pyotp.TOTP(credentials.key).now(),
+        "clientTime": int(time.time() * 1000),
+    }
 
 
 def parse_qr_code(payload: str) -> QrData:

--- a/custom_components/webuntis/utils/qrLogin.py
+++ b/custom_components/webuntis/utils/qrLogin.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import logging
-import time
 from dataclasses import dataclass
+import time
 from typing import Any
-from urllib.parse import parse_qs, urlparse
-
 import aiohttp
+from urllib.parse import parse_qs, urlparse
 import pyotp
 import webuntis
 from voluptuous import Error
@@ -20,9 +19,7 @@ API_VERSION = "i3.2"
 
 
 @dataclass(frozen=True)
-class WebUntisCredentials:
-    """Credentials extracted from the QR payload."""
-
+class qrData:
     server: str
     school: str
     user: str
@@ -30,81 +27,74 @@ class WebUntisCredentials:
     school_number: str | None = None
 
 
-def _normalize_server(server: str) -> str:
-    """Return a host name that can be used by webuntis.Session."""
+def _normalize_server_url(server: str) -> str:
     parsed = urlparse(server if "://" in server else f"https://{server}")
-    host = parsed.netloc or parsed.path.split("/", 1)[0]
-    host = host.strip()
+    host = (parsed.netloc or parsed.path.split("/", 1)[0]).strip()
     if not host:
         raise ValueError("QR payload does not contain a valid server")
     return host
 
 
-def parse_qr_payload(payload: str) -> WebUntisCredentials:
+def parse_qr_code(payload: str) -> qrData:
     """Parse the untis:// QR payload."""
     payload = payload.strip()
 
     if not payload.startswith("untis://"):
-        if payload.startswith("?"):
-            payload = "untis://setschool" + payload
-        else:
+        if not payload.startswith("?"):
             raise ValueError("QR payload must start with untis://")
+        payload = f"untis://setschool{payload}"
 
-    parsed = urlparse(payload)
-    query = parse_qs(parsed.query)
+    parsed_result = urlparse(payload)
+    query = parse_qs(parsed_result.query)
 
-    def _first(name: str) -> str | None:
-        values = query.get(name)
-        return values[0] if values else None
+    # get the first value of a query parameter or None if not present
+    _first_obj = lambda name: next(iter(query.get(name, [])), None)
 
-    server = _first("url") or _first("server")
-    school = _first("school")
-    user = _first("user")
-    key = _first("key")
-    school_number = _first("schoolNumber")
+    server = _first_obj("url") or _first_obj("server")
+    school = _first_obj("school")
+    user = _first_obj("user")
+    key = _first_obj("key")
+    school_number = _first_obj("schoolNumber")
 
     if not all([server, school, user, key]):
         raise ValueError("QR payload is incomplete")
 
-    return WebUntisCredentials(
-        server=_normalize_server(server),
-        school=school,
-        user=user,
-        key=key,
+    return qrData(
+        server=_normalize_server_url(server), # type: ignore[arg-type]
+        school=school,  # type: ignore[arg-type]
+        user=user,  # type: ignore[arg-type]
+        key=key,  # type: ignore[arg-type]
         school_number=school_number,
     )
 
 
 def _extract_login_result(data: dict[str, Any]) -> dict[str, Any]:
     """Extract the fields expected by webuntis.Session.login_result."""
-    login_result: dict[str, Any] = {}
-
-    for key in ("personType", "personId", "klasseId"):
-        if key in data:
-            login_result[key] = data[key]
+    keys = ("personType", "personId", "klasseId")
+    login_result = {k: data[k] for k in keys if k in data}
 
     result = data.get("result")
     if isinstance(result, dict):
-        for key in ("personType", "personId", "klasseId"):
+        for key in keys:
             if key in result and key not in login_result:
                 login_result[key] = result[key]
 
     return login_result
 
 
-class WebUntisQrClient:
-    """Asynchronous QR login helper for the WebUntis JSON-RPC API."""
+class WebUntisQrLogin:
+    """Async QR login helper for the WebUntis JSON-RPC API."""
 
     def __init__(
         self,
-        credentials: WebUntisCredentials,
+        credentials: qrData,
         session: aiohttp.ClientSession,
     ) -> None:
         self._creds = credentials
         self._session = session
 
     @property
-    def credentials(self) -> WebUntisCredentials:
+    def credentials(self) -> qrData:
         return self._creds
 
     def _endpoint(self, method: str) -> str:
@@ -114,10 +104,9 @@ class WebUntisQrClient:
         )
 
     def _auth_block(self) -> dict[str, Any]:
-        totp = pyotp.TOTP(self._creds.key)
         return {
             "user": self._creds.user,
-            "otp": totp.now(),
+            "otp": pyotp.TOTP(self._creds.key).now(),
             "clientTime": int(time.time() * 1000),
         }
 
@@ -127,13 +116,11 @@ class WebUntisQrClient:
         body = {
             "id": "ha-webuntis-qr",
             "method": method,
-            "params": [
-                {
-                    "auth": self._auth_block(),
-                    "deviceOs": "AND",
-                    "deviceOsVersion": "13",
-                }
-            ],
+            "params": [{
+                "auth": self._auth_block(),
+                "deviceOs": "AND",
+                "deviceOsVersion": "13",
+            }],
             "jsonrpc": "2.0",
         }
         headers = {
@@ -150,24 +137,19 @@ class WebUntisQrClient:
             resp.raise_for_status()
             data = await resp.json(content_type=None)
 
-            if data.get("error"):
-                raise Error(
-                    f"WebUntis error: {data['error'].get('message', data['error'])}"
-                )
+            if error := data.get("error"):
+                msg = error.get("message", error) if isinstance(error, dict) else error
+                raise Error(f"WebUntis error: {msg}")
 
-            jsessionid = resp.cookies.get("JSESSIONID")
-            if not jsessionid:
+            if not (jsessionid := resp.cookies.get("JSESSIONID")):
                 raise Error("Could not find JSESSIONID in QR login response")
 
-            result = data.get("result", {})
-            if not isinstance(result, dict):
-                result = {}
-
-            return result, jsessionid.value
+            result = data.get("result")
+            return result if isinstance(result, dict) else {}, jsessionid.value
 
     def create_session(self, jsessionid: str) -> webuntis.Session:
         """Create a standard webuntis.Session bound to the QR cookie."""
-        session = webuntis.Session(
+        return webuntis.Session(
             server=self._creds.server,
             school=self._creds.school,
             username=self._creds.user,
@@ -175,7 +157,6 @@ class WebUntisQrClient:
             jsessionid=jsessionid,
             useragent="home-assistant",
         )
-        return session
 
     @staticmethod
     def login_result_from_user_data(user_data: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/webuntis/utils/qrLogin.py
+++ b/custom_components/webuntis/utils/qrLogin.py
@@ -1,0 +1,183 @@
+"""Helpers for WebUntis QR-code login."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import aiohttp
+import pyotp
+import webuntis
+from voluptuous import Error
+
+_LOGGER = logging.getLogger(__name__)
+
+USER_AGENT = "UntisMobileAndroid"
+API_VERSION = "i3.2"
+
+
+@dataclass(frozen=True)
+class WebUntisCredentials:
+    """Credentials extracted from the QR payload."""
+
+    server: str
+    school: str
+    user: str
+    key: str
+    school_number: str | None = None
+
+
+def _normalize_server(server: str) -> str:
+    """Return a host name that can be used by webuntis.Session."""
+    parsed = urlparse(server if "://" in server else f"https://{server}")
+    host = parsed.netloc or parsed.path.split("/", 1)[0]
+    host = host.strip()
+    if not host:
+        raise ValueError("QR payload does not contain a valid server")
+    return host
+
+
+def parse_qr_payload(payload: str) -> WebUntisCredentials:
+    """Parse the untis:// QR payload."""
+    payload = payload.strip()
+
+    if not payload.startswith("untis://"):
+        if payload.startswith("?"):
+            payload = "untis://setschool" + payload
+        else:
+            raise ValueError("QR payload must start with untis://")
+
+    parsed = urlparse(payload)
+    query = parse_qs(parsed.query)
+
+    def _first(name: str) -> str | None:
+        values = query.get(name)
+        return values[0] if values else None
+
+    server = _first("url") or _first("server")
+    school = _first("school")
+    user = _first("user")
+    key = _first("key")
+    school_number = _first("schoolNumber")
+
+    if not all([server, school, user, key]):
+        raise ValueError("QR payload is incomplete")
+
+    return WebUntisCredentials(
+        server=_normalize_server(server),
+        school=school,
+        user=user,
+        key=key,
+        school_number=school_number,
+    )
+
+
+def _extract_login_result(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract the fields expected by webuntis.Session.login_result."""
+    login_result: dict[str, Any] = {}
+
+    for key in ("personType", "personId", "klasseId"):
+        if key in data:
+            login_result[key] = data[key]
+
+    result = data.get("result")
+    if isinstance(result, dict):
+        for key in ("personType", "personId", "klasseId"):
+            if key in result and key not in login_result:
+                login_result[key] = result[key]
+
+    return login_result
+
+
+class WebUntisQrClient:
+    """Asynchronous QR login helper for the WebUntis JSON-RPC API."""
+
+    def __init__(
+        self,
+        credentials: WebUntisCredentials,
+        session: aiohttp.ClientSession,
+    ) -> None:
+        self._creds = credentials
+        self._session = session
+
+    @property
+    def credentials(self) -> WebUntisCredentials:
+        return self._creds
+
+    def _endpoint(self, method: str) -> str:
+        return (
+            f"https://{self._creds.server}/WebUntis/jsonrpc_intern.do"
+            f"?m={method}&school={self._creds.school}&v={API_VERSION}"
+        )
+
+    def _auth_block(self) -> dict[str, Any]:
+        totp = pyotp.TOTP(self._creds.key)
+        return {
+            "user": self._creds.user,
+            "otp": totp.now(),
+            "clientTime": int(time.time() * 1000),
+        }
+
+    async def async_login(self) -> tuple[dict[str, Any], str]:
+        """Return the WebUntis user data and JSESSIONID."""
+        method = "getUserData2017"
+        body = {
+            "id": "ha-webuntis-qr",
+            "method": method,
+            "params": [
+                {
+                    "auth": self._auth_block(),
+                    "deviceOs": "AND",
+                    "deviceOsVersion": "13",
+                }
+            ],
+            "jsonrpc": "2.0",
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+        }
+
+        async with self._session.post(
+            self._endpoint(method),
+            json=body,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=20),
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json(content_type=None)
+
+            if data.get("error"):
+                raise Error(
+                    f"WebUntis error: {data['error'].get('message', data['error'])}"
+                )
+
+            jsessionid = resp.cookies.get("JSESSIONID")
+            if not jsessionid:
+                raise Error("Could not find JSESSIONID in QR login response")
+
+            result = data.get("result", {})
+            if not isinstance(result, dict):
+                result = {}
+
+            return result, jsessionid.value
+
+    def create_session(self, jsessionid: str) -> webuntis.Session:
+        """Create a standard webuntis.Session bound to the QR cookie."""
+        session = webuntis.Session(
+            server=self._creds.server,
+            school=self._creds.school,
+            username=self._creds.user,
+            password="",
+            jsessionid=jsessionid,
+            useragent="home-assistant",
+        )
+        return session
+
+    @staticmethod
+    def login_result_from_user_data(user_data: dict[str, Any]) -> dict[str, Any]:
+        """Convert QR user data into a standard session login_result payload."""
+        return _extract_login_result(user_data)

--- a/custom_components/webuntis/utils/qrLogin.py
+++ b/custom_components/webuntis/utils/qrLogin.py
@@ -107,7 +107,6 @@ async def async_qr_login(
         response.raise_for_status()
         data = await response.json(content_type=None)
 
-        # Prüfen, ob WebUntis ein explizites Error-Objekt geschickt hat
         error = data.get("error")
         if error:
             message = error.get("message", error) if isinstance(error, dict) else error
@@ -117,21 +116,17 @@ async def async_qr_login(
         result = data.get("result")
         user_data = result if isinstance(result, dict) else {}
 
-        # --- JSESSIONID EXTRAKTION (3-Wege-Fallback) ---
         jsessionid = None
 
-        # Weg A: Direkte Abfrage aus den Response-Cookies
         if "JSESSIONID" in response.cookies:
             jsessionid = response.cookies["JSESSIONID"].value
 
-        # Weg B: Aus dem CookieJar der ClientSession suchen
         if not jsessionid and client_session.cookie_jar:
             for cookie in client_session.cookie_jar:
                 if cookie.key == "JSESSIONID":
                     jsessionid = cookie.value
                     break
 
-        # Weg C: Aus den rohen 'Set-Cookie' Headern parsen
         if not jsessionid:
             set_cookie_headers = response.headers.getall("Set-Cookie", [])
             for header in set_cookie_headers:
@@ -139,7 +134,6 @@ async def async_qr_login(
                     jsessionid = header.split("JSESSIONID=")[1].split(";")[0].strip()
                     break
 
-        # Weg D: Fallback aus dem JSON-Body
         if not jsessionid and isinstance(user_data, dict):
             jsessionid = user_data.get("sessionId")
 

--- a/custom_components/webuntis/utils/qrLogin.py
+++ b/custom_components/webuntis/utils/qrLogin.py
@@ -2,29 +2,20 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
-import time
-from typing import Any
-import aiohttp
 from urllib.parse import parse_qs, urlparse
-import pyotp
-import webuntis
-from voluptuous import Error
-
-_LOGGER = logging.getLogger(__name__)
-
-USER_AGENT = "UntisMobileAndroid"
-API_VERSION = "i3.2"
 
 
 @dataclass(frozen=True)
-class qrData:
+class QrData:
     server: str
     school: str
     user: str
     key: str
     school_number: str | None = None
+
+
+qrData = QrData
 
 
 def _normalize_server_url(server: str) -> str:
@@ -35,7 +26,7 @@ def _normalize_server_url(server: str) -> str:
     return host
 
 
-def parse_qr_code(payload: str) -> qrData:
+def parse_qr_code(payload: str) -> QrData:
     """Parse the untis:// QR payload."""
     payload = payload.strip()
 
@@ -47,118 +38,24 @@ def parse_qr_code(payload: str) -> qrData:
     parsed_result = urlparse(payload)
     query = parse_qs(parsed_result.query)
 
-    # get the first value of a query parameter or None if not present
-    _first_obj = lambda name: next(iter(query.get(name, [])), None)
+    # get the first value of a query parameter or None
+    def _first_value(name: str) -> str | None:
+        value = next(iter(query.get(name, [])), None)
+        return value if isinstance(value, str) else None
 
-    server = _first_obj("url") or _first_obj("server")
-    school = _first_obj("school")
-    user = _first_obj("user")
-    key = _first_obj("key")
-    school_number = _first_obj("schoolNumber")
+    server = _first_value("url") or _first_value("server")
+    school = _first_value("school")
+    user = _first_value("user")
+    key = _first_value("key")
+    school_number = _first_value("schoolNumber")
 
-    if not all([server, school, user, key]):
+    if server is None or school is None or user is None or key is None:
         raise ValueError("QR payload is incomplete")
 
-    return qrData(
-        server=_normalize_server_url(server), # type: ignore[arg-type]
-        school=school,  # type: ignore[arg-type]
-        user=user,  # type: ignore[arg-type]
-        key=key,  # type: ignore[arg-type]
+    return QrData(
+        server=_normalize_server_url(server),
+        school=school,
+        user=user,
+        key=key,
         school_number=school_number,
     )
-
-
-def _extract_login_result(data: dict[str, Any]) -> dict[str, Any]:
-    """Extract the fields expected by webuntis.Session.login_result."""
-    keys = ("personType", "personId", "klasseId")
-    login_result = {k: data[k] for k in keys if k in data}
-
-    result = data.get("result")
-    if isinstance(result, dict):
-        for key in keys:
-            if key in result and key not in login_result:
-                login_result[key] = result[key]
-
-    return login_result
-
-
-class WebUntisQrLogin:
-    """Async QR login helper for the WebUntis JSON-RPC API."""
-
-    def __init__(
-        self,
-        credentials: qrData,
-        session: aiohttp.ClientSession,
-    ) -> None:
-        self._creds = credentials
-        self._session = session
-
-    @property
-    def credentials(self) -> qrData:
-        return self._creds
-
-    def _endpoint(self, method: str) -> str:
-        return (
-            f"https://{self._creds.server}/WebUntis/jsonrpc_intern.do"
-            f"?m={method}&school={self._creds.school}&v={API_VERSION}"
-        )
-
-    def _auth_block(self) -> dict[str, Any]:
-        return {
-            "user": self._creds.user,
-            "otp": pyotp.TOTP(self._creds.key).now(),
-            "clientTime": int(time.time() * 1000),
-        }
-
-    async def async_login(self) -> tuple[dict[str, Any], str]:
-        """Return the WebUntis user data and JSESSIONID."""
-        method = "getUserData2017"
-        body = {
-            "id": "ha-webuntis-qr",
-            "method": method,
-            "params": [{
-                "auth": self._auth_block(),
-                "deviceOs": "AND",
-                "deviceOsVersion": "13",
-            }],
-            "jsonrpc": "2.0",
-        }
-        headers = {
-            "Content-Type": "application/json",
-            "User-Agent": USER_AGENT,
-        }
-
-        async with self._session.post(
-            self._endpoint(method),
-            json=body,
-            headers=headers,
-            timeout=aiohttp.ClientTimeout(total=20),
-        ) as resp:
-            resp.raise_for_status()
-            data = await resp.json(content_type=None)
-
-            if error := data.get("error"):
-                msg = error.get("message", error) if isinstance(error, dict) else error
-                raise Error(f"WebUntis error: {msg}")
-
-            if not (jsessionid := resp.cookies.get("JSESSIONID")):
-                raise Error("Could not find JSESSIONID in QR login response")
-
-            result = data.get("result")
-            return result if isinstance(result, dict) else {}, jsessionid.value
-
-    def create_session(self, jsessionid: str) -> webuntis.Session:
-        """Create a standard webuntis.Session bound to the QR cookie."""
-        return webuntis.Session(
-            server=self._creds.server,
-            school=self._creds.school,
-            username=self._creds.user,
-            password="",
-            jsessionid=jsessionid,
-            useragent="home-assistant",
-        )
-
-    @staticmethod
-    def login_result_from_user_data(user_data: dict[str, Any]) -> dict[str, Any]:
-        """Convert QR user data into a standard session login_result payload."""
-        return _extract_login_result(user_data)

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -1,12 +1,18 @@
-import requests
 import json
+import time
+from typing import Any
+
+import aiohttp
+import pyotp
+import requests
 from webuntis import errors
 from webuntis.utils import log  # pylint: disable=no-name-in-module
 from webuntis.session import Session as WebUntisSession
 
-import logging
+from qrLogin import QrData
 
-# logging.basicConfig(level=logging.DEBUG)
+QR_USER_AGENT = "UntisMobileAndroid"
+QR_API_VERSION = "i3.2"
 
 
 class ExtendedSession(WebUntisSession):
@@ -14,6 +20,106 @@ class ExtendedSession(WebUntisSession):
     This class extends the original Session to include new functionality for
     fetching homeworks from the WebUntis API using a different endpoint.
     """
+
+    @staticmethod
+    def _extract_login_result(data: dict[str, Any]) -> dict[str, Any]:
+        """Extract fields expected by webuntis.Session.login_result."""
+        keys = ("personType", "personId", "klasseId")
+        login_result = {key: data[key] for key in keys if key in data}
+
+        result = data.get("result")
+        if isinstance(result, dict):
+            for key in keys:
+                if key in result and key not in login_result:
+                    login_result[key] = result[key]
+
+        return login_result
+
+    @staticmethod
+    def _qr_endpoint(credentials: QrData, method: str) -> str:
+        return (
+            f"https://{credentials.server}/WebUntis/jsonrpc_intern.do"
+            f"?m={method}&school={credentials.school}&v={QR_API_VERSION}"
+        )
+
+    @staticmethod
+    def _qr_auth_block(credentials: QrData) -> dict[str, Any]:
+        """Generate auth block for QR login."""
+        return {
+            "user": credentials.user,
+            "otp": pyotp.TOTP(credentials.key).now(),
+            "clientTime": int(time.time() * 1000),
+        }
+
+    @classmethod
+    async def async_qr_login(
+        cls,
+        credentials: QrData,
+        client_session: aiohttp.ClientSession,
+    ) -> tuple[dict[str, Any], str]:
+        """Authenticate via QR credentials and return user payload and JSESSIONID."""
+        method = "getUserData2017"
+        body = {
+            "id": "ha-webuntis-qr",
+            "method": method,
+            "params": [
+                {
+                    "auth": cls._qr_auth_block(credentials),
+                    "deviceOs": "AND",
+                    "deviceOsVersion": "13",
+                }
+            ],
+            "jsonrpc": "2.0",
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": QR_USER_AGENT,
+        }
+
+        async with client_session.post(
+            cls._qr_endpoint(credentials, method),
+            json=body,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=20),
+        ) as response:
+            response.raise_for_status()
+            data = await response.json(content_type=None)
+
+            error = data.get("error")
+            if error:
+                message = (
+                    error.get("message", error) if isinstance(error, dict) else error
+                )
+                raise errors.NotLoggedInError(f"WebUntis error: {message}")
+
+            jsessionid = response.cookies.get("JSESSIONID")
+            if jsessionid is None:
+                raise errors.NotLoggedInError(
+                    "Could not find JSESSIONID in QR login response"
+                )
+
+            result = data.get("result")
+            user_data = result if isinstance(result, dict) else {}
+            return user_data, jsessionid.value
+
+    @classmethod
+    async def async_create_from_qr(
+        cls,
+        credentials: QrData,
+        client_session: aiohttp.ClientSession,
+    ) -> tuple["ExtendedSession", str]:
+        """Create an authenticated ExtendedSession from QR credentials."""
+        user_data, jsessionid = await cls.async_qr_login(credentials, client_session)
+        session = cls(
+            server=f"https://{credentials.server}",
+            school=credentials.school,
+            username=credentials.user,
+            password="",
+            jsessionid=jsessionid,
+            useragent="home-assistant",
+        )
+        session.login_result = cls._extract_login_result(user_data)
+        return session, jsessionid
 
     def _send_custom_request(self, endpoint, params):
         """
@@ -37,7 +143,7 @@ class ExtendedSession(WebUntisSession):
 
         # Ensure session is logged in
         if "jsessionid" in self.config:
-            headers["Cookie"] = f'JSESSIONID={self.config["jsessionid"]}'
+            headers["Cookie"] = f"JSESSIONID={self.config['jsessionid']}"
         else:
             raise errors.NotLoggedInError("No JSESSIONID found. Please log in first.")
 

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -27,10 +27,8 @@ class ExtendedSession(WebUntisSession):
         client_session: aiohttp.ClientSession,
     ) -> tuple["ExtendedSession", str]:
         """Create an authenticated ExtendedSession from QR credentials."""
-        # 1. QR-Login über die ausgelagerte Funktion durchführen
         user_data, jsessionid = await async_qr_login(credentials, client_session)
 
-        # 2. Session-Instanz aufbauen
         session = cls(
             server=f"https://{credentials.server}",
             school=credentials.school,
@@ -40,7 +38,6 @@ class ExtendedSession(WebUntisSession):
             useragent="home-assistant",
         )
 
-        # 3. Login-Ergebnis verarbeiten und zuweisen
         session.login_result = extract_login_result(user_data)
         return session, jsessionid
 
@@ -59,12 +56,8 @@ class ExtendedSession(WebUntisSession):
             self._session.cookies.set("JSESSIONID", jsessionid)
 
     def _request(self, method, params=None, use_login_repeat=None):
-        if (
-            use_login_repeat is None
-            and (
-                "password" not in self.config
-                or not self.config["password"]
-            )
+        if use_login_repeat is None and (
+            "password" not in self.config or not self.config["password"]
         ):
             use_login_repeat = False
 

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -140,8 +140,8 @@ class ExtendedSession(WebUntisSession):
             jsessionid=jsessionid,
             useragent="home-assistant",
         )
+
         session.login_result = cls._extract_login_result(user_data)
-        print("login result - extendedSession: %s", session.login_result)
         return session, jsessionid
 
     def _request(self, method, params=None, use_login_repeat=None):

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -9,7 +9,7 @@ from webuntis import errors
 from webuntis.utils import log  # pylint: disable=no-name-in-module
 from webuntis.session import Session as WebUntisSession
 
-from qrLogin import QrData
+from .qrLogin import QrData
 
 QR_USER_AGENT = "UntisMobileAndroid"
 QR_API_VERSION = "i3.2"
@@ -23,15 +23,37 @@ class ExtendedSession(WebUntisSession):
 
     @staticmethod
     def _extract_login_result(data: dict[str, Any]) -> dict[str, Any]:
-        """Extract fields expected by webuntis.Session.login_result."""
-        keys = ("personType", "personId", "klasseId")
-        login_result = {key: data[key] for key in keys if key in data}
+        """Extract fields expected by webuntis.Session.login_result from QR user_data."""
+        login_result = {}
 
-        result = data.get("result")
-        if isinstance(result, dict):
-            for key in keys:
-                if key in result and key not in login_result:
-                    login_result[key] = result[key]
+        # Custom ID mapping
+        type_map = {
+            "KLASSE": 1,
+            "TEACHER": 2,
+            "SUBJECT": 3,
+            "ROOM": 4,
+            "STUDENT": 5,
+        }
+
+        user_data = data.get("userData", {}) if isinstance(data, dict) else {}
+
+        if "elemId" in user_data:
+            login_result["personId"] = user_data["elemId"]
+
+        if "elemType" in user_data:
+            elem_type = user_data["elemType"]
+            if isinstance(elem_type, str):
+                login_result["personType"] = type_map.get(elem_type.upper(), 5)
+            else:
+                login_result["personType"] = elem_type
+
+        if user_data.get("klassenIds"):
+            login_result["klasseId"] = user_data["klassenIds"][0]
+
+        # fallback for default keys
+        for key in ("personType", "personId", "klasseId"):
+            if key in data and key not in login_result:
+                login_result[key] = data[key]
 
         return login_result
 
@@ -119,6 +141,7 @@ class ExtendedSession(WebUntisSession):
             useragent="home-assistant",
         )
         session.login_result = cls._extract_login_result(user_data)
+        print("login result - extendedSession: %s", session.login_result)
         return session, jsessionid
 
     def _request(self, method, params=None, use_login_repeat=None):

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -59,6 +59,15 @@ class ExtendedSession(WebUntisSession):
             self._session.cookies.set("JSESSIONID", jsessionid)
 
     def _request(self, method, params=None, use_login_repeat=None):
+        if (
+            use_login_repeat is None
+            and (
+                "password" not in self.config
+                or not self.config["password"]
+            )
+        ):
+            use_login_repeat = False
+
         try:
             return super()._request(
                 method, params=params, use_login_repeat=use_login_repeat

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -3,13 +3,12 @@ import time
 from typing import Any
 
 import aiohttp
-import pyotp
 import requests
 from webuntis import errors
 from webuntis.utils import log  # pylint: disable=no-name-in-module
 from webuntis.session import Session as WebUntisSession
 
-from .qrLogin import QrData
+from .qrLogin import QrData, async_qr_login, extract_login_result
 
 QR_USER_AGENT = "UntisMobileAndroid"
 QR_API_VERSION = "i3.2"
@@ -21,109 +20,6 @@ class ExtendedSession(WebUntisSession):
     fetching homeworks from the WebUntis API using a different endpoint.
     """
 
-    @staticmethod
-    def _extract_login_result(data: dict[str, Any]) -> dict[str, Any]:
-        """Extract fields expected by webuntis.Session.login_result from QR user_data."""
-        login_result = {}
-
-        # Custom ID mapping
-        type_map = {
-            "KLASSE": 1,
-            "TEACHER": 2,
-            "SUBJECT": 3,
-            "ROOM": 4,
-            "STUDENT": 5,
-        }
-
-        user_data = data.get("userData", {}) if isinstance(data, dict) else {}
-
-        if "elemId" in user_data:
-            login_result["personId"] = user_data["elemId"]
-
-        if "elemType" in user_data:
-            elem_type = user_data["elemType"]
-            if isinstance(elem_type, str):
-                login_result["personType"] = type_map.get(elem_type.upper(), 5)
-            else:
-                login_result["personType"] = elem_type
-
-        if user_data.get("klassenIds"):
-            login_result["klasseId"] = user_data["klassenIds"][0]
-
-        # fallback for default keys
-        for key in ("personType", "personId", "klasseId"):
-            if key in data and key not in login_result:
-                login_result[key] = data[key]
-
-        return login_result
-
-    @staticmethod
-    def _qr_endpoint(credentials: QrData, method: str) -> str:
-        return (
-            f"https://{credentials.server}/WebUntis/jsonrpc_intern.do"
-            f"?m={method}&school={credentials.school}&v={QR_API_VERSION}"
-        )
-
-    @staticmethod
-    def _qr_auth_block(credentials: QrData) -> dict[str, Any]:
-        """Generate auth block for QR login."""
-        return {
-            "user": credentials.user,
-            "otp": pyotp.TOTP(credentials.key).now(),
-            "clientTime": int(time.time() * 1000),
-        }
-
-    @classmethod
-    async def async_qr_login(
-        cls,
-        credentials: QrData,
-        client_session: aiohttp.ClientSession,
-    ) -> tuple[dict[str, Any], str]:
-        """Authenticate via QR credentials and return user payload and JSESSIONID."""
-        method = "getUserData2017"
-        body = {
-            "id": "ha-webuntis-qr",
-            "method": method,
-            "params": [
-                {
-                    "auth": cls._qr_auth_block(credentials),
-                    "deviceOs": "AND",
-                    "deviceOsVersion": "13",
-                }
-            ],
-            "jsonrpc": "2.0",
-        }
-        headers = {
-            "Content-Type": "application/json",
-            "User-Agent": QR_USER_AGENT,
-        }
-
-        async with client_session.post(
-            cls._qr_endpoint(credentials, method),
-            json=body,
-            headers=headers,
-            timeout=aiohttp.ClientTimeout(total=20),
-        ) as response:
-            response.raise_for_status()
-            data = await response.json(content_type=None)
-
-            error = data.get("error")
-            if error:
-                message = (
-                    error.get("message", error) if isinstance(error, dict) else error
-                )
-                raise errors.NotLoggedInError(f"WebUntis error: {message}")
-
-            jsessionid = response.cookies.get("JSESSIONID")
-            if jsessionid is None:
-                raise errors.NotLoggedInError(
-                    "Could not find JSESSIONID in QR login response"
-                )
-
-            result = data.get("result")
-            user_data = result if isinstance(result, dict) else {}
-            return user_data, jsessionid.value
-
     @classmethod
     async def async_create_from_qr(
         cls,
@@ -131,7 +27,10 @@ class ExtendedSession(WebUntisSession):
         client_session: aiohttp.ClientSession,
     ) -> tuple["ExtendedSession", str]:
         """Create an authenticated ExtendedSession from QR credentials."""
-        user_data, jsessionid = await cls.async_qr_login(credentials, client_session)
+        # 1. QR-Login über die ausgelagerte Funktion durchführen
+        user_data, jsessionid = await async_qr_login(credentials, client_session)
+
+        # 2. Session-Instanz aufbauen
         session = cls(
             server=f"https://{credentials.server}",
             school=credentials.school,
@@ -141,7 +40,8 @@ class ExtendedSession(WebUntisSession):
             useragent="home-assistant",
         )
 
-        session.login_result = cls._extract_login_result(user_data)
+        # 3. Login-Ergebnis verarbeiten und zuweisen
+        session.login_result = extract_login_result(user_data)
         return session, jsessionid
 
     def _request(self, method, params=None, use_login_repeat=None):

--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -44,6 +44,20 @@ class ExtendedSession(WebUntisSession):
         session.login_result = extract_login_result(user_data)
         return session, jsessionid
 
+    async def async_refresh_qr(
+        self,
+        credentials: QrData,
+        client_session: aiohttp.ClientSession,
+    ) -> None:
+        """Refresh JSESSIONID using QR credentials ."""
+        user_data, jsessionid = await async_qr_login(credentials, client_session)
+
+        self.config["jsessionid"] = jsessionid
+        self.login_result = extract_login_result(user_data)
+
+        if hasattr(self, "_session") and self._session is not None:
+            self._session.cookies.set("JSESSIONID", jsessionid)
+
     def _request(self, method, params=None, use_login_repeat=None):
         try:
             return super()._request(


### PR DESCRIPTION
Fixes #111


### Change
- Implement QR Code login with a custom RPC request

- It generates an TOTP and sends a request. The response contains a jsessionId which is extracted and saved. The id is used for creating a python-webuntis Session, so it is compatible with the existing code.

I also added me to the codeowners in the manifest file. I thought that would be appropriate, since I have also contributed many code parts in the last time. It's only a suggestion, I can undo it everytime :)

### Testing
I tested it for a longer day and fixed all the bugs which came so far.

# ToDos
- [X] Integrate QR Code session creation code into webuntis_extended
- [x] Fix "not authenticated" after HA restart (jsessionid is probably lost after restart)
- [X] Fix: Auto session refresh (after some hours the sessions seems to expire)
- [x] Fix: Entities get unavailable in the next polling (after 10min) before refresh 
- [x] Feat: Manual Inputs for the 4 credential fields (in the same step with if!)