### PR TITLE
Refactor schoolyear logic to avoid errors during summer holidays

### DIFF
--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -26,6 +26,7 @@ from webuntis import errors
 from .utils.web_untis_extended import ExtendedSession
 from .utils.homework import return_homework_events
 from .utils.exams import return_exam_events
+from .utils.schoolyears import resolve_schoolyear
 from .utils.web_untis import get_lesson_name
 
 
@@ -326,7 +327,7 @@ class WebUntis:
                 self.session.schoolyears
             )
             self.current_schoolyear = await self._hass.async_add_executor_job(
-                lambda: self.schoolyears.current
+                resolve_schoolyear, self.schoolyears
             )
 
             if not self.current_schoolyear:
@@ -351,6 +352,16 @@ class WebUntis:
                 self._last_status_request_failed = True
                 await self._hass.async_add_executor_job(self.webuntis_logout)
                 return
+
+            self._last_status_request_failed = False
+            _LOGGER.debug(
+                "Using schoolyear '%s' for '%s@%s' (start=%s, end=%s)",
+                self.current_schoolyear.name,
+                self.school,
+                self.username,
+                self.current_schoolyear.start.date(),
+                self.current_schoolyear.end.date(),
+            )
 
         except OSError as error:
             _LOGGER.warning(
@@ -572,14 +583,10 @@ class WebUntis:
                 _LOGGER.debug("No session id found")
                 self._loged_in = False
             else:
-                # Check if session id is still valid.
-                try:
-                    self.session.schoolyears()
-                    self.updating += 1
-                    return None
-                except errors.NotLoggedInError:
-                    _LOGGER.debug("Session invalid")
-                    self._loged_in = False
+                # Keep the existing session if the cookie is still present.
+                # WebUntis' schoolyear probe can emit -8998 during holiday gaps.
+                self.updating += 1
+                return None
 
         if not self._loged_in:
             # _LOGGER.debug("logging in")
@@ -645,6 +652,11 @@ class WebUntis:
                 self.timetable_source_id, self.timetable_source, self.session
             )
 
+        if isinstance(start, datetime):
+            start = start.date()
+        if isinstance(end, datetime):
+            end = end.date()
+
         if not self.current_schoolyear:
             _LOGGER.debug(
                 "No valid school year found for start date %s. Returning empty timetable.",
@@ -657,6 +669,16 @@ class WebUntis:
             start = self.current_schoolyear.start.date()
         if end > self.current_schoolyear.end.date():
             end = self.current_schoolyear.end.date()
+
+        if start > end:
+            _LOGGER.debug(
+                "Requested timetable range %s-%s is outside school year %s-%s. Returning empty timetable.",
+                start,
+                end,
+                self.current_schoolyear.start.date(),
+                self.current_schoolyear.end.date(),
+            )
+            return []
 
         result = []
         if self.timetable_source == "personal":

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -31,6 +31,7 @@ from .const import (
 )
 from .notify import get_notification_data
 from .utils.errors import *
+from .utils.schoolyears import resolve_schoolyear
 from .utils.utils import async_notify, is_service
 from .utils.web_untis import get_timetable_object
 from .utils.search_schools import search_schools
@@ -220,7 +221,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
 
                 current_schoolyear = await self.hass.async_add_executor_job(
-                    self._safe_current_schoolyear, schoolyears
+                    resolve_schoolyear, schoolyears
                 )
                 if current_schoolyear:
                     return await self.async_step_pick_klasse()
@@ -503,7 +504,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         day = datetime.date.today()
         schoolyears = session.schoolyears()
-        current_schoolyear = self._safe_current_schoolyear(schoolyears)
+        current_schoolyear = resolve_schoolyear(schoolyears)
         if not current_schoolyear:
             if schoolyears:
                 day = schoolyears[-1].start.date()
@@ -541,16 +542,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             _LOGGER.error("Error testing timetable: %s", exc)
             return {"base": "unknown"}
-
-    @staticmethod
-    def _safe_current_schoolyear(schoolyears):
-        """Return the current schoolyear, or None when WebUntis has none."""
-
-        try:
-            return schoolyears.current
-        except webuntis.errors.RemoteError:
-            return None
-
 
 OPTIONS_MENU = [
     "filter",

--- a/custom_components/webuntis/utils/exams.py
+++ b/custom_components/webuntis/utils/exams.py
@@ -6,6 +6,7 @@ from webuntis.utils.datetime_utils import parse_datetime
 
 # pylint: disable=relative-beyond-top-level
 from ..utils.web_untis import get_lesson_name_str
+from ..utils.schoolyears import resolve_schoolyear
 
 
 class ExamEventsFetcher:
@@ -20,14 +21,20 @@ class ExamEventsFetcher:
         Fetch exam events from the WebUntis API using the session object and return them as a list of event dictionaries.
         """
 
-        if not self.current_schoolyear:
+        schoolyear = resolve_schoolyear(getattr(self.server, "schoolyears", None))
+        if not schoolyear:
             return []
 
         # Fetch exam data using the session object
+        schoolyear_start = schoolyear.start.date()
+        schoolyear_end = schoolyear.end.date()
+        if schoolyear_start > schoolyear_end:
+            return []
+
         try:
             exam_data = self.session.get_exams(
-                start=self.current_schoolyear.start.date(),
-                end=self.current_schoolyear.end.date(),
+                start=schoolyear_start,
+                end=schoolyear_end,
             )
         except errors.NotLoggedInError:
             raise Exception("You are not logged in. Please log in and try again.")

--- a/custom_components/webuntis/utils/homework.py
+++ b/custom_components/webuntis/utils/homework.py
@@ -8,6 +8,7 @@ from custom_components.webuntis.const import DAYS_TO_CHECK
 
 # pylint: disable=relative-beyond-top-level
 from ..utils.web_untis import get_lesson_name_str
+from ..utils.schoolyears import resolve_schoolyear
 
 
 class HomeworkEventsFetcher:
@@ -32,6 +33,16 @@ class HomeworkEventsFetcher:
         today = date.today()
         start = today - timedelta(days=DAYS_TO_CHECK)
         end = today + timedelta(days=DAYS_TO_CHECK)
+
+        schoolyear = resolve_schoolyear(getattr(self.server, "schoolyears", None))
+        if schoolyear:
+            schoolyear_start = schoolyear.start.date()
+            schoolyear_end = schoolyear.end.date()
+            if end < schoolyear_start or start > schoolyear_end:
+                return [], []
+
+            start = max(start, schoolyear_start)
+            end = min(end, schoolyear_end)
 
         # Fetch homework data using the session object
         try:

--- a/custom_components/webuntis/utils/schoolyears.py
+++ b/custom_components/webuntis/utils/schoolyears.py
@@ -1,0 +1,50 @@
+"""Helpers for working with WebUntis schoolyears."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+
+def resolve_schoolyear(schoolyears: Any):
+    """Return a usable schoolyear without relying on WebUntis' broken current property.
+
+    Preference order:
+    1. A schoolyear that contains today's date.
+    2. The next future schoolyear, for summer holiday gaps.
+    3. The most recent past schoolyear, as a last resort.
+    """
+
+    if not schoolyears:
+        return None
+
+    today = date.today()
+    schoolyear_list = list(schoolyears)
+    current_schoolyears = []
+    future_schoolyears = []
+    past_schoolyears = []
+
+    for schoolyear in schoolyear_list:
+        try:
+            start = schoolyear.start.date()
+            end = schoolyear.end.date()
+        except Exception:
+            continue
+
+        if start <= today <= end:
+            current_schoolyears.append(schoolyear)
+        elif start > today:
+            future_schoolyears.append(schoolyear)
+        else:
+            past_schoolyears.append(schoolyear)
+
+    if current_schoolyears:
+        return sorted(current_schoolyears, key=lambda item: item.start)[0]
+
+    if future_schoolyears:
+        return sorted(future_schoolyears, key=lambda item: item.start)[0]
+
+    if past_schoolyears:
+        return sorted(past_schoolyears, key=lambda item: item.end)[-1]
+
+    return schoolyear_list[0] if schoolyear_list else None

--- a/custom_components/webuntis/utils/schoolyears.py
+++ b/custom_components/webuntis/utils/schoolyears.py
@@ -7,12 +7,12 @@ from typing import Any
 
 
 def resolve_schoolyear(schoolyears: Any):
-    """Return a usable schoolyear without relying on WebUntis' broken current property.
+    """Return a usable schoolyear without relying on unreliable python-webuntis package.
 
     Preference order:
-    1. A schoolyear that contains today's date.
-    2. The next future schoolyear, for summer holiday gaps.
-    3. The most recent past schoolyear, as a last resort.
+    1. A schoolyear that contains today's date
+    2. The next future schoolyear, for summer holiday gaps
+    3. The most recent past schoolyear
     """
 
     if not schoolyears:


### PR DESCRIPTION
Fixes #297 

The schoolyear logic from the python-webuntis package is very bad and causes many problems like #297 (I could reproduced this). This PR fixes that by adding custom school year logic.