### PR TITLE
Fix calendar events overlapping requested date range

### DIFF
--- a/custom_components/webuntis/calendar.py
+++ b/custom_components/webuntis/calendar.py
@@ -98,7 +98,7 @@ class BaseUntisCalendar(WebUntisEntity, CalendarEntity):
                 event_end = event_end.replace(tzinfo=timezone)
 
             # Now compare the event start and end with the given range
-            if event_start >= start_date and event_end <= end_date:
+            if event_end > start_date and event_start < end_date:
                 events_in_range.append(event)
 
         return events_in_range


### PR DESCRIPTION
<html><head></head><body><h1>🐛 Fix calendar event range filtering</h1><h2>📌 Problem</h2><p>The current implementation only returns events that are <strong>completely contained within the requested date range</strong>:</p><pre><code class="language-python">if event_start &gt;= start_date and event_end &lt;= end_date:
    events_in_range.append(event)
</code></pre><p>This causes events that started before the requested range but are still active during the range to be excluded.</p><h3>Example</h3><p>Given the following event:</p><pre><code class="language-text">Event:    25 Aug ───────────────────── 29 Aug
</code></pre><p>And the following requested range:</p><pre><code class="language-text">Range:             27 Aug ───────────────────── 30 Aug
</code></pre><p>The event overlaps with the requested range and should therefore be returned.</p><p>However, with the previous implementation:</p><pre><code class="language-python">event_start &gt;= start_date

25 Aug &gt;= 27 Aug  ❌
</code></pre><p>The event is incorrectly excluded.</p><hr><h2>📚 Home Assistant documentation</h2><p>According to the [Home Assistant Calendar Entity documentation](https://developers.home-assistant.io/docs/core/entity/calendar/#get-events):</p><ul><li><p><code inline="">start_date</code> is the lower bound and is applied to an event's <strong>end</strong>.</p></li><li><p><code inline="">end_date</code> is the upper bound and is applied to an event's <strong>start</strong>.</p></li><li><p>Both bounds are <strong>exclusive</strong>.</p></li></ul><p>This means that an event should be returned whenever it overlaps with the requested time range.</p><hr><h2>🔧 Changes</h2><p>The range check was changed from:</p><pre><code class="language-python">if event_start &gt;= start_date and event_end &lt;= end_date:
</code></pre><p>to:</p><pre><code class="language-python">if event_end &gt; start_date and event_start &lt; end_date:
</code></pre><p>This checks whether the event overlaps with the requested range.</p><p>An event is included when:</p><pre><code class="language-text">Event ends after the requested start
AND
Event starts before the requested end
</code></pre><hr><h2>📊 Examples</h2>
Event | Requested range | Result
-- | -- | --
25 Aug – 29 Aug | 27 Aug – 30 Aug | ✅ Returned
27 Aug – 29 Aug | 27 Aug – 30 Aug | ✅ Returned
29 Aug – 31 Aug | 27 Aug – 30 Aug | ✅ Returned
20 Aug – 40 Aug | 27 Aug – 30 Aug | ✅ Returned
25 Aug – 27 Aug | 27 Aug – 30 Aug | ❌ Not returned
30 Aug – 31 Aug | 27 Aug – 30 Aug | ❌ Not returned

<hr><h2>✅ Result</h2><p>Calendar events are now correctly returned when they <strong>overlap with the requested date range</strong>, including events that started before the requested range but are still active within it.</p><p>This behavior matches the expectations documented for Home Assistant <code inline="">CalendarEntity.async_get_events()</code>and also aligns with the behavior of the Untis Mobile app, which displays events that overlap with the selected date range.</p>
</body></html>