### PR TITLE
Update for Timetable Card wth native WebUntis Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ You can install WebUntis via HACS or manually. For detailed instructions, see th
 
 ---
 
+## Dashboard Card for Timetable
 
-## Dashboard card for timetable
-There is an inofficial dashboard card for displaying timetables in Home Assistant.
-The card is not related to this project, but it is compatible with the timetable provided by this integration
+For a better experience in Home Assistant, you can use the HA-Timetable-Card. It is designed to work with the timetable data provided by this integration and offers a more detailed and flexible way to display your timetable.
+
+> [!NOTE]
+> The Timetable Card is not limited to the upcoming 30 days.
+> The integration provides the upcoming 30 days by default, while the Timetable Card can request and display timetable data for a larger date range.
 
 Check it out here: https://github.com/KingDando8430/HA-Timetable-Card
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ For a better experience in Home Assistant, you can use the HA-Timetable-Card. It
 
 Check it out here: https://github.com/KingDando8430/HA-Timetable-Card
 
+See the [WebUntis x Timetable Card Documentation](https://github.com/KingDando8430/HA-Timetable-Card/blob/main/documentation/WebUntis.md) for more information.
+
 ---
 
 ## [![Join our Discord](https://discordapp.com/api/guilds/1090218586565509170/widget.png?style=banner2)](https://discord.gg/34EHnHQaPm)

--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ You can install WebUntis via HACS or manually. For detailed instructions, see th
 
 ## Dashboard Card for Timetable
 
-For a better experience in Home Assistant, you can use the HA-Timetable-Card. It is designed to work with the timetable data provided by this integration and offers a more detailed and flexible way to display your timetable.
+For a better visual experience in Home Assistant, you can use the HA-Timetable-Card. It is designed to work with the timetable data provided by this integration and offers a more detailed and flexible way to display your timetable.
 
 > [!NOTE]
-> The Timetable Card is not limited to the upcoming 30 days.
-> The integration provides the upcoming 30 days by default, while the Timetable Card can request and display timetable data for a larger date range.
+> While this integration provides a calendar entitiy with the upcoming 30 days, the timetable card can request and display timetable data for a larger date range.
 
 Check it out here: https://github.com/KingDando8430/HA-Timetable-Card
 


### PR DESCRIPTION
[Timetable Card](https://github.com/KingDando8430/HA-Timetable-Card) bekommt mit [v1.3.0](https://github.com/KingDando8430/HA-Timetable-Card/releases/tag/v1.3.0) nativen Support für WebUntis Geräte die von dieser Integration kommen. Dafür wurde die Beschreibung in der README.md angepasst. 

Timetable Card bekommt unter anderem folgende Features:
* Den Stundenplan anzeigen, den die calendar entity liefert
* Nach 30 Tagen, bzw. wenn keine Daten mehr vorhanden sind, über `webuntis.get_timetable` den Stundenplan für die kommenden Wochen abfragen
* Auswählen ob man die abgefragten Daten mit kurzen/langem Name (für lesson) haben will
* Auswählen ob man die abgefragten Daten mit kurzen/langem Ort Namen (für location) haben will