### PR TITLE
Add Live Activities (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can install WebUntis via HACS or manually. For detailed instructions, see th
 
 - **Entities & Services** – Full list of entities, their German/English names, and available services:
   [Entities & Services](docs/ENTITIES_AND_SERVICES.md)
-- **Optional Configurations** – All configuration options for filters, calendars, lessons, notifications, and backend:
+- **Optional Configurations** – All configuration options for filters, calendars, lessons, notifications, live timetable, and backend:
   [Optional Configurations](docs/OPTIONAL_CONFIGURATIONS.md)
 - **Examples & Automations** – Ready-to-use automations and template snippets for common use cases:
   [Examples & Automations](docs/EXAMPLES_AND_AUTOMATIONS.md)

--- a/README.md
+++ b/README.md
@@ -12,20 +12,21 @@
 
 ---
 
-## 🌟 Features
+## Features
 
 | Feature | Description | Link |
 |---------|-------------|------|
-| 📅 **30-Day Calendar** | Displays all lessons in the calendar or calendar-card for the upcoming month. | [Entities & Services](docs/ENTITIES_AND_SERVICES.md) |
-| ⏰ **Lesson Sensors** | Includes school start/end times and next lesson, useful for wake-up automations. | [Examples & Automations](docs/EXAMPLES_AND_AUTOMATIONS.md) |
-| 🔔 **Lesson Change Notifications** | Get notified for cancellations, room changes, teacher changes, and lesson swaps. | [Notification Options](docs/OPTIONAL_CONFIGURATIONS.md#notification-options) |
-| 📝 **Fetch Lessons Service** | Request lessons for a specific date range. | [`webuntis.get_timetable`](docs/ENTITIES_AND_SERVICES.md#-webuntisget_timetable) |
-| 📊 **Count Lessons Service** | Count lessons by subject within a given date range. | [`webuntis.count_lessons`](docs/ENTITIES_AND_SERVICES.md#-webuntiscount_lessons) |
+| **30-Day Calendar** | Displays all lessons in the calendar or calendar-card for the upcoming month. | [Entities & Services](docs/ENTITIES_AND_SERVICES.md) |
+| **Lesson Sensors** | Includes school start/end times and next lesson, useful for wake-up automations. | [Examples & Automations](docs/EXAMPLES_AND_AUTOMATIONS.md) |
+| **Lesson Change Notifications** | Get notified for cancellations, room changes, teacher changes, and lesson swaps. | [Notification Options](docs/OPTIONAL_CONFIGURATIONS.md#notification-options) |
+| **Live Timetable (Live Activities)** | Display the current timetable in a live view on your phone or tablet. (Currently only available for iOS) | [Live Activities](docs/OPTIONAL_CONFIGURATIONS.md#live-activities) |
+| **Fetch Lessons Service** | Request lessons for a specific date range. | [`webuntis.get_timetable`](docs/ENTITIES_AND_SERVICES.md#-webuntisget_timetable) |
+| **Count Lessons Service** | Count lessons by subject within a given date range. | [`webuntis.count_lessons`](docs/ENTITIES_AND_SERVICES.md#-webuntiscount_lessons) |
 
 
 ---
 
-## 🚀 Setup
+## Setup
 [![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=JonasJoKuJonas&repository=Homeassistant-WebUntis)
 
 You can install WebUntis via HACS or manually. For detailed instructions, see the dedicated setup guide:

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -30,6 +30,7 @@ from .utils.web_untis import get_lesson_name
 
 
 from .const import (
+    CONF_LIVE_ACTIVITIES,
     CONFIG_ENTRY_VERSION,
     DAYS_TO_FUTURE,
     DEFAULT_OPTIONS,
@@ -39,6 +40,7 @@ from .const import (
     NAME_EVENT_LESSON_CHANGE,
     NAME_EVENT_HOMEWORK,
 )
+from .live_activities import LiveActivityManager
 from .notify import *
 from .services import async_setup_services
 from .utils.utils import compact_list, async_notify
@@ -71,6 +73,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await server.async_update()
     server.start_periodic_update()
+
+    server.live_activity_manager = LiveActivityManager(hass, server)
+    server.live_activity_manager.start()
 
     # Register update listener.
     entry.async_on_unload(entry.add_update_listener(async_update_entry))
@@ -149,6 +154,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
     # Clean up.
     server.stop_periodic_update()
+    server.live_activity_manager.stop()
     hass.data[DOMAIN].pop(unique_id)
 
     return unload_ok
@@ -212,6 +218,9 @@ class WebUntis:
         self.notify = any(
             config.get("options") for config in self.notify_config.values()
         )
+
+        self.live_activities = config.options.get(CONF_LIVE_ACTIVITIES, {})
+        self.live_activity_manager = None
 
         self.session = ExtendedSession(
             username=self.username,

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -255,7 +255,7 @@ class WebUntis:
         )
 
 
-                self.live_activities = config.options.get(CONF_LIVE_ACTIVITIES, {})
+        self.live_activities = config.options.get(CONF_LIVE_ACTIVITIES, {})
         self.live_activity_manager = None
 
         session_kwargs = {

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 from collections.abc import Callable, Mapping
@@ -104,7 +105,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     for option, default in DEFAULT_OPTIONS.items():
         if option not in options:
-            options[option] = default
+            options[option] = copy.deepcopy(default)
 
     if config_entry.version == 14:
         if "notify_entity_id" in options:

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -29,6 +29,7 @@ from .const import (
     NOTIFY_OPTIONS,
     TEMPLATE_OPTIONS,
 )
+from .live_activities import LiveActivityOptionsFlowMixin
 from .notify import get_notification_data
 from .utils.errors import *
 from .utils.utils import async_notify, is_service
@@ -557,11 +558,12 @@ OPTIONS_MENU = [
     "calendar",
     "lesson",
     "notify_menu",
+    "live_activities_menu",
     "backend",
 ]
 
 
-class OptionsFlowHandler(config_entries.OptionsFlow):
+class OptionsFlowHandler(config_entries.OptionsFlow, LiveActivityOptionsFlowMixin):
     """Handle the option flow for WebUntis."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import datetime
 import logging
 import socket
@@ -520,7 +521,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=user_input["username"],
             data=user_input,
-            options=DEFAULT_OPTIONS,
+            options=copy.deepcopy(DEFAULT_OPTIONS),
         )
 
     def _show_form_user(

--- a/custom_components/webuntis/const.py
+++ b/custom_components/webuntis/const.py
@@ -2,7 +2,9 @@
 
 DOMAIN = "webuntis"
 
-CONFIG_ENTRY_VERSION = 21
+CONFIG_ENTRY_VERSION = 22
+
+CONF_LIVE_ACTIVITIES = "live_activities"
 
 DEFAULT_OPTIONS = {
     "lesson_long_name": True,
@@ -21,7 +23,10 @@ DEFAULT_OPTIONS = {
     "notify_config": {},
     "invalid_subjects": False,
     "exclude_filter_comparison": False,
+    "live_activities": {},
 }
+
+LIVE_ACTIVITY_TAG_SUFFIX = "live_stundenplan"
 
 NOTIFY_OPTIONS = [
     "homework",

--- a/custom_components/webuntis/const.py
+++ b/custom_components/webuntis/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "webuntis"
 
-CONFIG_ENTRY_VERSION = 22
+CONFIG_ENTRY_VERSION = 23
 
 CONF_LIVE_ACTIVITIES = "live_activities"
 

--- a/custom_components/webuntis/live_activities.py
+++ b/custom_components/webuntis/live_activities.py
@@ -1,0 +1,628 @@
+"""Live Activities for the daily timetable."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_validation as cv, issue_registry as ir, selector
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.event import async_call_later, async_track_point_in_time
+
+from .const import (
+    CONF_LIVE_ACTIVITIES,
+    DOMAIN,
+    ICON_SENSOR_NEXT_LESSON_TO_WAKE_UP,
+    ICON_SENSOR_TODAY_END,
+    LIVE_ACTIVITY_TAG_SUFFIX,
+)
+from .utils.utils import async_notify, is_service
+from .utils.web_untis import get_lesson_name
+
+_LOGGER = logging.getLogger(__name__)
+
+MAX_ACTIVITY_DURATION = timedelta(hours=8)
+
+with (Path(__file__).parent / "translations" / "live_activity_strings.json").open(
+    encoding="utf-8"
+) as _f:
+    _STRINGS: dict[str, dict[str, Any]] = json.load(_f)
+
+
+# --------------------------------------------------------------------------
+# Pure helpers
+# --------------------------------------------------------------------------
+
+
+def _language(hass: HomeAssistant) -> str:
+    lang = (hass.config.language or "en").split("-")[0].lower()
+    return lang if lang in _STRINGS else "en"
+
+
+def _service_id_for_entity(hass: HomeAssistant, entity_id: str) -> str | None:
+    """Return the legacy notify.mobile_app_<device> action for a notify.* entity."""
+    object_id = entity_id.split(".", 1)[-1]
+    if not object_id.startswith("mobile_app_"):
+        object_id = f"mobile_app_{object_id}"
+    service_id = f"notify.{object_id}"
+    issue_id = f"live_activity_notify_missing_{entity_id}"
+
+    if not is_service(hass, service_id):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="live_activity_notify_missing",
+            translation_placeholders={"entity_id": entity_id, "service_id": service_id},
+        )
+        return None
+
+    ir.async_delete_issue(hass, DOMAIN, issue_id)
+    return service_id
+
+
+def _build_tag(username: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9_-]", "_", username or "")
+    return f"{sanitized}_{LIVE_ACTIVITY_TAG_SUFFIX}"[:64]
+
+
+def _format_time(dt: datetime) -> str:
+    return f"{dt.hour}:{dt.minute:02d}"
+
+
+def _day_word(lang: str, target: date, today: date) -> str:
+    delta = (target - today).days
+    strings = _STRINGS[lang]
+    if delta == 1:
+        return strings["tomorrow"]
+    if 1 < delta < 7:
+        return strings["weekday"][target.weekday()]
+    return f'{strings["on_prefix"]} {target.strftime("%d.%m.")}'
+
+
+# --------------------------------------------------------------------------
+# Timetable parsing
+# --------------------------------------------------------------------------
+
+
+def _build_day_blocks(server: Any, day: date) -> list[dict]:
+    """Fetch, filter and merge today's lessons into blocks."""
+    try:
+        login_error = server.webuntis_login()
+    except Exception as error:  # pylint: disable=broad-except
+        login_error = error
+
+    if login_error:
+        _LOGGER.warning("Live Stundenplan: login failed for %s - %s", day, login_error)
+        return []
+
+    try:
+        lessons = server.get_timetable(start=day, end=day, sort=True)
+    except Exception as error:  # pylint: disable=broad-except
+        _LOGGER.warning("Live Stundenplan: could not load timetable for %s - %s", day, error)
+        return []
+    finally:
+        try:
+            server.webuntis_logout()
+        except Exception as error:  # pylint: disable=broad-except
+            _LOGGER.debug("Live Stundenplan: logout after timetable fetch failed - %s", error)
+
+    tolerance = timedelta(minutes=server.lesson_compacting_tolerance)
+
+    items = []
+    for lesson in lessons:
+        if not server.check_lesson(lesson):
+            continue
+        try:
+            room = lesson.rooms[0].name if lesson.rooms else ""
+        except (IndexError, AttributeError):
+            room = ""
+        items.append(
+            {
+                "start": lesson.start.astimezone(),
+                "end": lesson.end.astimezone(),
+                "lsnumber": getattr(lesson, "lsnumber", None),
+                "subject": get_lesson_name(server, lesson),
+                "room": room,
+            }
+        )
+    items.sort(key=lambda i: i["start"])
+
+    blocks: list[dict] = []
+    for item in items:
+        if (
+            blocks
+            and item["start"] >= blocks[-1]["end"]
+            and item["start"] - blocks[-1]["end"] <= tolerance
+            and item["lsnumber"] == blocks[-1]["lsnumber"]
+        ):
+            blocks[-1]["end"] = item["end"]
+            continue
+        blocks.append(dict(item))
+
+    return blocks
+
+
+def _build_events(blocks: list[dict], start_offset: int, end_offset: int) -> list[dict]:
+    """Turn today's blocks into a timeline of (time, phase, block) events."""
+    if not blocks:
+        return []
+
+    events: list[dict] = []
+    first, last = blocks[0], blocks[-1]
+
+    events.append(
+        {
+            "time": first["start"] - timedelta(minutes=start_offset),
+            "phase": "schulbeginn",
+            "block": first,
+            "restart": False,
+        }
+    )
+
+    for i, block in enumerate(blocks):
+        events.append({"time": block["start"], "phase": "unterricht", "block": block, "restart": False})
+        if i + 1 < len(blocks):
+            following = blocks[i + 1]
+            if following["start"] > block["end"]:
+                events.append(
+                    {"time": block["end"], "phase": "pause", "block": following, "restart": False}
+                )
+
+    events.append({"time": last["end"], "phase": "schulende", "block": None, "restart": False})
+    events.append(
+        {
+            "time": last["end"] + timedelta(minutes=end_offset),
+            "phase": "clear",
+            "block": None,
+            "restart": False,
+        }
+    )
+
+    events.sort(key=lambda e: e["time"])
+    return events
+
+
+def _flag_restart(events: list[dict]) -> None:
+    """Flag the pause closest to the midpoint for a restart."""
+    if not events:
+        return
+    span = events[-1]["time"] - events[0]["time"]
+    if span <= MAX_ACTIVITY_DURATION:
+        return
+
+    midpoint = events[0]["time"] + span / 2
+    pauses = [e for e in events if e["phase"] == "pause"]
+    if not pauses:
+        _LOGGER.warning(
+            "Live Stundenplan: school day is longer than 8h and has no break to "
+            "restart the Live Activity during - it may end early once iOS's "
+            "limit is hit."
+        )
+        return
+
+    closest = min(pauses, key=lambda e: abs((e["time"] - midpoint).total_seconds()))
+    closest["restart"] = True
+
+
+def _current_phase(events: list[dict], now: datetime) -> dict | None:
+    """Most recent event that is due, i.e. what should be showing right now."""
+    past = [e for e in events if e["time"] <= now]
+    if not past:
+        return None
+    return max(past, key=lambda e: e["time"])
+
+
+def _signature(event: dict) -> tuple:
+    """Identifies the displayed content, so unchanged phases are not resent."""
+    phase = event["phase"]
+    block = event["block"]
+    if phase in ("schulbeginn", "unterricht"):
+        return (phase, block["start"].isoformat(), block["end"].isoformat(), block["subject"], block["room"])
+    if phase == "pause":
+        return (phase, block["subject"], block["room"])
+    return (phase,)
+
+
+def _build_payload(
+    event: dict, lang: str, next_school_day: datetime | None
+) -> tuple[str, str, dict]:
+    """Build the (title, message, extra_data) triple for one phase."""
+    phase = event["phase"]
+    block = event["block"]
+    strings = _STRINGS[lang]
+    lesson_text = f'{block["subject"]} - R{block["room"]}' if block else ""
+
+    when: datetime | None = None
+
+    if phase == "schulbeginn":
+        title = strings["school_start_title"]
+        message = "\n".join([strings["school_start_begin"].format(time=_format_time(block["start"])), lesson_text])
+        icon, color, silent = ICON_SENSOR_NEXT_LESSON_TO_WAKE_UP, "#2196F3", False
+    elif phase == "unterricht":
+        title = lesson_text
+        message = " "
+        icon, color, silent, when = "mdi:school", "orange", True, block["end"]
+    elif phase == "pause":
+        title = strings["break_title"]
+        message = strings["break_next"].format(lesson=lesson_text)
+        icon, color, silent = "mdi:school-outline", "lightgreen", False
+    elif phase == "schulende":
+        if next_school_day:
+            day_word = _day_word(lang, next_school_day.date(), date.today())
+            time_str = _format_time(next_school_day)
+        else:
+            day_word = time_str = "?"
+        title = strings["school_end_title"]
+        message = strings["school_end_next"].format(day=day_word, time=time_str)
+        icon, color, silent = ICON_SENSOR_TODAY_END, "white", True
+    else:
+        return "", "", {}
+
+    extra = {
+        "notification_icon": icon,
+        "notification_icon_color": color,
+        "silent": silent,
+    }
+    if when is not None:
+        extra["chronometer"] = True
+        extra["when"] = int(when.timestamp())
+
+    return title, message, extra
+
+
+# --------------------------------------------------------------------------
+# Test send
+# --------------------------------------------------------------------------
+
+TEST_TAG_SUFFIX = "live_stundenplan_test"
+TEST_ACTIVITY_DURATION = timedelta(seconds=60)
+
+
+def _build_test_tag(entity_id: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9_-]", "_", entity_id or "")
+    return f"{sanitized}_{TEST_TAG_SUFFIX}"[:64]
+
+
+async def async_send_test(hass: HomeAssistant, entity_id: str, lang: str) -> bool:
+    """Send one real, standalone test Live Activity and self-clear shortly after."""
+    service_id = _service_id_for_entity(hass, entity_id)
+    if service_id is None:
+        return False
+    tag = _build_test_tag(entity_id)
+    strings = _STRINGS[lang]
+    now = datetime.now().astimezone()
+
+    success = await async_notify(
+        hass,
+        service_id,
+        {
+            "title": strings["test_title"],
+            "message": strings["test_message"],
+            "data": {
+                "tag": tag,
+                "live_update": True,
+                "silent": False,
+                "chronometer": True,
+                "when": int((now + TEST_ACTIVITY_DURATION).timestamp()),
+                "notification_icon": "mdi:bell-ring-outline",
+                "notification_icon_color": "#2196F3",
+            },
+        },
+    )
+
+    if success:
+
+        @callback
+        def _clear(_now: datetime) -> None:
+            hass.async_create_task(
+                async_notify(hass, service_id, {"message": "clear_notification", "data": {"tag": tag}})
+            )
+
+        async_call_later(hass, TEST_ACTIVITY_DURATION.total_seconds(), _clear)
+
+    return success
+
+
+# --------------------------------------------------------------------------
+# Send scheduling
+# --------------------------------------------------------------------------
+
+
+class LiveActivityManager:
+
+    def __init__(self, hass: HomeAssistant, server: Any) -> None:
+        self.hass = hass
+        self.server = server
+        self._unsub_dispatcher = None
+        self._unsub_timers: list = []
+        self._last_sent: dict[str, tuple] = {}
+        self._restarted: set[tuple[str, str]] = set()
+        self._cleared_dates: dict[str, date] = {}
+
+    def start(self) -> None:
+        self._unsub_dispatcher = async_dispatcher_connect(
+            self.hass, self.server.signal_name, self._handle_update
+        )
+        self._handle_update()
+
+    def stop(self) -> None:
+        for unsub in self._unsub_timers:
+            unsub()
+        self._unsub_timers = []
+        if self._unsub_dispatcher:
+            self._unsub_dispatcher()
+            self._unsub_dispatcher = None
+
+    @callback
+    def _handle_update(self, *_args: Any) -> None:
+        self.hass.async_create_task(self._async_sync())
+
+    @callback
+    def _handle_timer(self, *_args: Any) -> None:
+        self.hass.async_create_task(self._async_sync())
+
+    async def _async_sync(self) -> None:
+        targets = self.server.live_activities
+        if not targets:
+            return
+
+        for unsub in self._unsub_timers:
+            unsub()
+        self._unsub_timers = []
+
+        today = date.today()
+        blocks = await self.hass.async_add_executor_job(_build_day_blocks, self.server, today)
+        lang = _language(self.hass)
+        now = datetime.now().astimezone()
+
+        next_time: datetime | None = None
+        for target in targets.values():
+            events = _build_events(blocks, target.get("start_offset", 10), target.get("end_offset", 10))
+            _flag_restart(events)
+
+            future = [e["time"] for e in events if e["time"] > now]
+            if future:
+                soonest = min(future)
+                next_time = soonest if next_time is None else min(next_time, soonest)
+
+            await self._sync_target(target, events, now, lang, today)
+
+        self._prune(today)
+
+        if next_time is not None:
+            self._unsub_timers.append(
+                async_track_point_in_time(self.hass, self._handle_timer, next_time)
+            )
+
+    async def _sync_target(
+        self, target: dict, events: list[dict], now: datetime, lang: str, today: date
+    ) -> None:
+        entity_id = target["entity_id"]
+        service_id = _service_id_for_entity(self.hass, entity_id)
+        if service_id is None:
+            return
+        tag = _build_tag(self.server.username)
+
+        current = _current_phase(events, now)
+        if current is None:
+            return
+
+        if current["phase"] == "clear":
+            if self._cleared_dates.get(entity_id) != today:
+                await async_notify(
+                    self.hass, service_id, {"message": "clear_notification", "data": {"tag": tag}}
+                )
+                self._cleared_dates[entity_id] = today
+                self._last_sent.pop(entity_id, None)
+            return
+
+        signature = _signature(current)
+        if self._last_sent.get(entity_id) == signature:
+            return
+
+        if current["phase"] == "pause" and current["restart"]:
+            restart_key = (entity_id, current["block"]["start"].isoformat())
+            if restart_key not in self._restarted:
+                await async_notify(
+                    self.hass, service_id, {"message": "clear_notification", "data": {"tag": tag}}
+                )
+                self._restarted.add(restart_key)
+
+        next_school_day = (
+            self.server.next_lesson_to_wake_up if current["phase"] == "schulende" else None
+        )
+        title, message, extra = _build_payload(current, lang, next_school_day)
+
+        await async_notify(
+            self.hass,
+            service_id,
+            {
+                "title": title,
+                "message": message,
+                "data": {"tag": tag, "live_update": True, **extra},
+            },
+        )
+        self._last_sent[entity_id] = signature
+
+    def _prune(self, today: date) -> None:
+        """Drop old bookkeeping so long uptimes don't grow these forever."""
+        cutoff = (today - timedelta(days=2)).isoformat()
+        self._cleared_dates = {
+            entity_id: cleared_on
+            for entity_id, cleared_on in self._cleared_dates.items()
+            if cleared_on.isoformat() >= cutoff
+        }
+        self._restarted = {
+            (entity_id, start_iso) for entity_id, start_iso in self._restarted if start_iso >= cutoff
+        }
+
+
+# --------------------------------------------------------------------------
+# Options flow
+# --------------------------------------------------------------------------
+
+
+class LiveActivityOptionsFlowMixin:
+    """Mixed into OptionsFlowHandler; expects self._config_entry/self.hass/self.save."""
+
+    async def list_live_activities(
+        self,
+        step_id: str,
+        multible: bool = False,
+        required: bool = True,
+        errors: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        activities = {
+            entity_id: activity["name"]
+            for entity_id, activity in self._config_entry.options[CONF_LIVE_ACTIVITIES].items()
+        }
+
+        select = cv.multi_select if multible else vol.In
+        required_marker = vol.Required if required else vol.Optional
+
+        return self.async_show_form(
+            step_id=step_id,
+            errors=errors or {},
+            data_schema=vol.Schema({required_marker("services"): select(activities)}),
+        )
+
+    async def async_step_live_activities_menu(
+        self,
+        user_input: dict[str, str] | None = None,  # pylint: disable=unused-argument
+    ) -> FlowResult:
+        """Manage the live_activities_menu options."""
+        if not self._config_entry.options[CONF_LIVE_ACTIVITIES]:
+            options = ["edit_live_activity"]
+        else:
+            options = [
+                "edit_live_activity",
+                "edit_live_activity_select",
+                "remove_live_activity",
+                "test_live_activity",
+            ]
+        return self.async_show_menu(step_id="live_activities_menu", menu_options=options)
+
+    async def async_step_test_live_activity(
+        self,
+        user_input: dict[str, str] | None = None,
+        errors: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Send a real test Live Activity right away."""
+        if user_input is None:
+            return await self.list_live_activities(
+                "test_live_activity", multible=True, required=False, errors=errors
+            )
+
+        lang = _language(self.hass)
+        for entity_id in user_input.get("services", {}):
+            if not await async_send_test(self.hass, entity_id, lang):
+                return await self.async_step_test_live_activity(
+                    None, errors={"base": "notification_invalid"}
+                )
+
+        return await self.save({})
+
+    async def async_step_edit_live_activity_select(
+        self,
+        user_input: dict[str, str] | None = None,
+    ) -> FlowResult:
+        if user_input is None:
+            return await self.list_live_activities("edit_live_activity_select")
+        return await self.async_step_edit_live_activity(edit=user_input["services"])
+
+    async def async_step_remove_live_activity(
+        self,
+        user_input: dict[str, str] | None = None,
+    ) -> FlowResult:
+        if user_input is None:
+            return await self.list_live_activities("remove_live_activity", multible=True)
+
+        live_activities = self._config_entry.options[CONF_LIVE_ACTIVITIES]
+        for key in user_input["services"]:
+            live_activities.pop(key, None)
+            ir.async_delete_issue(self.hass, DOMAIN, f"live_activity_notify_missing_{key}")
+        return await self.save(
+            {
+                CONF_LIVE_ACTIVITIES: live_activities,
+                "toggle": not self._config_entry.options.get("toggle"),
+            }
+        )
+
+    async def async_step_edit_live_activity(
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
+        edit: str | None = None,
+    ) -> FlowResult:
+        options: dict[str, Any] = {}
+        if edit:
+            options = self._config_entry.options[CONF_LIVE_ACTIVITIES].get(edit, {})
+
+        if user_input is not None:
+            if "name" not in user_input:
+                user_input["name"] = user_input["entity_id"]
+
+            live_activities = self._config_entry.options[CONF_LIVE_ACTIVITIES]
+            live_activities[user_input["entity_id"]] = user_input
+            return await self.save(
+                {
+                    CONF_LIVE_ACTIVITIES: live_activities,
+                    "toggle": not self._config_entry.options.get("toggle"),
+                }
+            )
+
+        schema = {
+            vol.Optional(
+                "name",
+                description={"suggested_value": options.get("name")},
+            ): selector.TextSelector(),
+            vol.Required(
+                "platform",
+                description={"suggested_value": options.get("platform")},
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=["ios"],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    translation_key="live_activity_platform",
+                )
+            ),
+            vol.Required(
+                "entity_id",
+                description={"suggested_value": options.get("entity_id")},
+            ): selector.EntitySelector(selector.EntitySelectorConfig(domain="notify")),
+            vol.Optional(
+                "start_offset",
+                default=10,
+                description={"suggested_value": options.get("start_offset", 10)},
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, step=1, unit_of_measurement="min", mode=selector.NumberSelectorMode.BOX
+                )
+            ),
+            vol.Optional(
+                "end_offset",
+                default=10,
+                description={"suggested_value": options.get("end_offset", 10)},
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, step=1, unit_of_measurement="min", mode=selector.NumberSelectorMode.BOX
+                )
+            ),
+        }
+
+        return self.async_show_form(
+            step_id="edit_live_activity",
+            data_schema=vol.Schema(schema),
+            errors=errors,
+        )

--- a/custom_components/webuntis/live_activities.py
+++ b/custom_components/webuntis/live_activities.py
@@ -164,22 +164,22 @@ def _build_events(blocks: list[dict], start_offset: int, end_offset: int) -> lis
     events.append(
         {
             "time": first["start"] - timedelta(minutes=start_offset),
-            "phase": "schulbeginn",
+            "phase": "school_start",
             "block": first,
             "restart": False,
         }
     )
 
     for i, block in enumerate(blocks):
-        events.append({"time": block["start"], "phase": "unterricht", "block": block, "restart": False})
+        events.append({"time": block["start"], "phase": "lesson", "block": block, "restart": False})
         if i + 1 < len(blocks):
             following = blocks[i + 1]
             if following["start"] > block["end"]:
                 events.append(
-                    {"time": block["end"], "phase": "pause", "block": following, "restart": False}
+                    {"time": block["end"], "phase": "break", "block": following, "restart": False}
                 )
 
-    events.append({"time": last["end"], "phase": "schulende", "block": None, "restart": False})
+    events.append({"time": last["end"], "phase": "school_end", "block": None, "restart": False})
     events.append(
         {
             "time": last["end"] + timedelta(minutes=end_offset),
@@ -202,7 +202,7 @@ def _flag_restart(events: list[dict]) -> None:
         return
 
     midpoint = events[0]["time"] + span / 2
-    pauses = [e for e in events if e["phase"] == "pause"]
+    pauses = [e for e in events if e["phase"] == "break"]
     if not pauses:
         _LOGGER.warning(
             "Live Stundenplan: school day is longer than 8h and has no break to "
@@ -227,9 +227,9 @@ def _signature(event: dict) -> tuple:
     """Identifies the displayed content, so unchanged phases are not resent."""
     phase = event["phase"]
     block = event["block"]
-    if phase in ("schulbeginn", "unterricht"):
+    if phase in ("school_start", "lesson"):
         return (phase, block["start"].isoformat(), block["end"].isoformat(), block["subject"], block["room"])
-    if phase == "pause":
+    if phase == "break":
         return (phase, block["subject"], block["room"])
     return (phase,)
 
@@ -245,19 +245,19 @@ def _build_payload(
 
     when: datetime | None = None
 
-    if phase == "schulbeginn":
+    if phase == "school_start":
         title = strings["school_start_title"]
         message = "\n".join([strings["school_start_begin"].format(time=_format_time(block["start"])), lesson_text])
         icon, color, silent = ICON_SENSOR_NEXT_LESSON_TO_WAKE_UP, "#2196F3", False
-    elif phase == "unterricht":
+    elif phase == "lesson":
         title = lesson_text
         message = " "
         icon, color, silent, when = "mdi:school", "orange", True, block["end"]
-    elif phase == "pause":
+    elif phase == "break":
         title = strings["break_title"]
         message = strings["break_next"].format(lesson=lesson_text)
         icon, color, silent, when = "mdi:school-outline", "lightgreen", False, block["start"]
-    elif phase == "schulende":
+    elif phase == "school_end":
         if next_school_day:
             day_word = _day_word(lang, next_school_day.date(), date.today())
             time_str = _format_time(next_school_day)
@@ -431,7 +431,7 @@ class LiveActivityManager:
         if self._last_sent.get(entity_id) == signature:
             return
 
-        if current["phase"] == "pause" and current["restart"]:
+        if current["phase"] == "break" and current["restart"]:
             restart_key = (entity_id, current["block"]["start"].isoformat())
             if restart_key not in self._restarted:
                 await async_notify(
@@ -440,7 +440,7 @@ class LiveActivityManager:
                 self._restarted.add(restart_key)
 
         next_school_day = (
-            self.server.next_lesson_to_wake_up if current["phase"] == "schulende" else None
+            self.server.next_lesson_to_wake_up if current["phase"] == "school_end" else None
         )
         title, message, extra = _build_payload(current, lang, next_school_day)
 

--- a/custom_components/webuntis/live_activities.py
+++ b/custom_components/webuntis/live_activities.py
@@ -256,7 +256,7 @@ def _build_payload(
     elif phase == "pause":
         title = strings["break_title"]
         message = strings["break_next"].format(lesson=lesson_text)
-        icon, color, silent = "mdi:school-outline", "lightgreen", False
+        icon, color, silent, when = "mdi:school-outline", "lightgreen", False, block["start"]
     elif phase == "schulende":
         if next_school_day:
             day_word = _day_word(lang, next_school_day.date(), date.today())

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -86,7 +86,8 @@
           "calendar": "Kalender",
           "lesson": "Stunden-Darstellung",
           "backend": "Backend",
-          "notify_menu": "Notify Menü"
+          "notify_menu": "Notify Menü",
+          "live_activities_menu": "Live Stundenplan"
         }
       },
       "filter": {
@@ -171,6 +172,21 @@
           "template": "Kann Benachrichtigungs-Daten überschreiben"
         }
       },
+      "edit_live_activity": {
+        "title": "Live Stundenplan",
+        "description": "Live Activity für den Stundenplan hinzufügen oder bearbeiten.",
+        "data": {
+          "name": "Name",
+          "platform": "Plattform",
+          "entity_id": "Notify-Dienst",
+          "start_offset": "Start vor Schulbeginn",
+          "end_offset": "Ende nach Schulschluss"
+        },
+        "data_description": {
+          "start_offset": "Minuten vor der ersten Stunde.",
+          "end_offset": "Minuten nach der letzten Stunde."
+        }
+      },
       "notify_menu": {
         "title": "Notify Dienst",
         "menu_options": {
@@ -178,6 +194,15 @@
           "edit_notify_service_select": "Notify Dienst bearbeiten",
           "remove_notify_service": "Notify Dienst löschen",
           "test_notify_service": "Notify Dienst testen"
+        }
+      },
+      "live_activities_menu": {
+        "title": "Live Stundenplan",
+        "menu_options": {
+          "edit_live_activity": "Live Stundenplan hinzufügen",
+          "edit_live_activity_select": "Live Stundenplan bearbeiten",
+          "remove_live_activity": "Live Stundenplan löschen",
+          "test_live_activity": "Live Stundenplan testen"
         }
       }
     }
@@ -220,6 +245,11 @@
         "class_name_short": "Klassen Name (kurz)",
         "class_name_long": "Klassen Name (lang)"
       }
+    },
+    "live_activity_platform": {
+      "options": {
+        "ios": "iOS"
+      }
     }
   },
   "issues": {
@@ -242,6 +272,10 @@
         }
       },
       "title": "Das Passwort wurde geändert"
+    },
+    "live_activity_notify_missing": {
+      "title": "Live Stundenplan: Notify-Ziel nicht erreichbar",
+      "description": "{entity_id} hat keine Aktion {service_id}. Ist das Ziel ein Gerät der Companion-App? Bitte in der Live-Stundenplan-Konfiguration prüfen."
     }
   },
   "services": {

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -227,7 +227,7 @@
         "title": "Kalender-Einstellungen"
       },
       "edit_live_activity": {
-        "title": "Live Stundenplan",
+        "title": "Live-Stundenplan",
         "description": "Live Activity für den Stundenplan hinzufügen oder bearbeiten.",
         "data": {
           "name": "Name",
@@ -242,10 +242,10 @@
         }
       },
       "edit_live_activity_select": {
-        "title": "Live Stundenplan",
-        "description": "Wähle den Live Stundenplan aus, der bearbeitet werden soll.",
+        "title": "Live-Stundenplan",
+        "description": "Wähle den Live-Stundenplan aus, der bearbeitet werden soll.",
         "data": {
-          "services": "Live Stundenplan"
+          "services": "Live-Stundenplan"
         }
       },
       "edit_notify_service": {
@@ -289,8 +289,8 @@
           "calendar": "Kalender",
           "filter": "Filter",
           "lesson": "Stunden-Darstellung",
-          "live_activities_menu": "Live Stundenplan",
-          "notify_menu": "Notify Menü"
+          "live_activities_menu": "Live-Stundenplan (Live Activities)",
+          "notify_menu": "Benarichtigungen"
         }
       },
       "lesson": {
@@ -311,12 +311,12 @@
         "title": "Stunden-Darstellungs-Einstellungen"
       },
       "live_activities_menu": {
-        "title": "Live Stundenplan",
+        "title": "Live-Stundenplan",
         "menu_options": {
-          "edit_live_activity": "Live Stundenplan hinzufügen",
-          "edit_live_activity_select": "Live Stundenplan bearbeiten",
-          "remove_live_activity": "Live Stundenplan löschen",
-          "test_live_activity": "Live Stundenplan testen"
+          "edit_live_activity": "Live-Stundenplan hinzufügen",
+          "edit_live_activity_select": "Live-Stundenplan bearbeiten",
+          "remove_live_activity": "Live-Stundenplan löschen",
+          "test_live_activity": "Live-Stundenplan testen"
         }
       },
       "notify_menu": {
@@ -329,17 +329,17 @@
         "title": "Notify Dienst"
       },
       "remove_live_activity": {
-        "title": "Live Stundenplan",
-        "description": "Wähle die Live Stundenpläne aus, die entfernt werden sollen.",
+        "title": "Live-Stundenplan",
+        "description": "Wähle die Live-Stundenpläne aus, die entfernt werden sollen.",
         "data": {
-          "services": "Live Stundenpläne"
+          "services": "Live-Stundenpläne"
         }
       },
       "test_live_activity": {
-        "title": "Live Stundenplan",
-        "description": "Wähle die Live Stundenpläne aus, an die eine Testbenachrichtigung gesendet werden soll.",
+        "title": "Live-Stundenplan",
+        "description": "Wähle die Live-Stundenpläne aus, an die eine Testbenachrichtigung gesendet werden soll.",
         "data": {
-          "services": "Live Stundenpläne"
+          "services": "Live-Stundenpläne"
         }
       }
     },

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -342,6 +342,8 @@
     "live_activity_platform": {
       "options": {
         "ios": "iOS"
+      }
+    },
     "homework_display": {
       "options": {
         "due_date": "Nur am Fälligkeitstag",

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -241,6 +241,13 @@
           "end_offset": "Minuten nach der letzten Stunde."
         }
       },
+      "edit_live_activity_select": {
+        "title": "Live Stundenplan",
+        "description": "Wähle den Live Stundenplan aus, der bearbeitet werden soll.",
+        "data": {
+          "services": "Live Stundenplan"
+        }
+      },
       "edit_notify_service": {
         "data": {
           "data": "Plattformspezifische Benachrichtigungs-Daten",
@@ -320,6 +327,20 @@
           "test_notify_service": "Notify Dienst testen"
         },
         "title": "Notify Dienst"
+      },
+      "remove_live_activity": {
+        "title": "Live Stundenplan",
+        "description": "Wähle die Live Stundenpläne aus, die entfernt werden sollen.",
+        "data": {
+          "services": "Live Stundenpläne"
+        }
+      },
+      "test_live_activity": {
+        "title": "Live Stundenplan",
+        "description": "Wähle die Live Stundenpläne aus, an die eine Testbenachrichtigung gesendet werden soll.",
+        "data": {
+          "services": "Live Stundenpläne"
+        }
       }
     },
     "error": {

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -290,7 +290,7 @@
           "filter": "Filter",
           "lesson": "Stunden-Darstellung",
           "live_activities_menu": "Live-Stundenplan (Live Activities)",
-          "notify_menu": "Benarichtigungen"
+          "notify_menu": "Benachrichtigungen"
         }
       },
       "lesson": {

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -86,7 +86,8 @@
           "calendar": "Calendar",
           "lesson": "Lesson Display",
           "backend": "Backend",
-          "notify_menu": "Notify Menu"
+          "notify_menu": "Notify Menu",
+          "live_activities_menu": "Live Timetable"
         }
       },
       "filter": {
@@ -171,6 +172,21 @@
           "template": "may overwrite data keys"
         }
       },
+      "edit_live_activity": {
+        "title": "Live Timetable",
+        "description": "Add or edit a Live Activity for the timetable.",
+        "data": {
+          "name": "Name",
+          "platform": "Platform",
+          "entity_id": "Notify Service",
+          "start_offset": "Start before school",
+          "end_offset": "End after school"
+        },
+        "data_description": {
+          "start_offset": "Minutes before the first lesson.",
+          "end_offset": "Minutes after the last lesson."
+        }
+      },
       "notify_menu": {
         "title": "Notify Service",
         "menu_options": {
@@ -178,6 +194,15 @@
           "edit_notify_service_select": "edit notify service",
           "remove_notify_service": "remove notify service",
           "test_notify_service": "test notify service"
+        }
+      },
+      "live_activities_menu": {
+        "title": "Live Timetable",
+        "menu_options": {
+          "edit_live_activity": "add Live Timetable",
+          "edit_live_activity_select": "edit Live Timetable",
+          "remove_live_activity": "remove Live Timetable",
+          "test_live_activity": "test Live Timetable"
         }
       }
     }
@@ -221,6 +246,11 @@
         "class_name_short": "Class Name (short)",
         "class_name_long": "Class Name (long)"
       }
+    },
+    "live_activity_platform": {
+      "options": {
+        "ios": "iOS"
+      }
     }
   },
   "issues": {
@@ -243,6 +273,10 @@
         }
       },
       "title": "Password has been changed"
+    },
+    "live_activity_notify_missing": {
+      "title": "Live Timetable: notify target unreachable",
+      "description": "{entity_id} has no {service_id} action. Is the target an Companion App device? Please check the Live Timetable configuration."
     }
   },
   "services": {

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -311,20 +311,20 @@
         "title": "Lesson Display Settings"
       },
       "live_activities_menu": {
-        "title": "Live Timetable",
+        "title": "Live Timetable (Live Activities)",
         "menu_options": {
-          "edit_live_activity": "add Live Timetable",
-          "edit_live_activity_select": "edit Live Timetable",
-          "remove_live_activity": "remove Live Timetable",
-          "test_live_activity": "test Live Timetable"
+          "edit_live_activity": "Add Live Timetable",
+          "edit_live_activity_select": "Edit Live Timetable",
+          "remove_live_activity": "Remove Live Timetable",
+          "test_live_activity": "Test Live Timetable"
         }
       },
       "notify_menu": {
         "menu_options": {
-          "edit_notify_service": "add notify service",
-          "edit_notify_service_select": "edit notify service",
-          "remove_notify_service": "remove notify service",
-          "test_notify_service": "test notify service"
+          "edit_notify_service": "Add notify service",
+          "edit_notify_service_select": "Edit notify service",
+          "remove_notify_service": "Remove notify service",
+          "test_notify_service": "Test notify service"
         },
         "title": "Notify Service"
       },

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -241,6 +241,13 @@
           "end_offset": "Minutes after the last lesson."
         }
       },
+      "edit_live_activity_select": {
+        "title": "Live Timetable",
+        "description": "Choose the Live Activity to edit.",
+        "data": {
+          "services": "Live Activity"
+        }
+      },
       "edit_notify_service": {
         "data": {
           "data": "Platform-Specific Notification Data",
@@ -320,6 +327,20 @@
           "test_notify_service": "test notify service"
         },
         "title": "Notify Service"
+      },
+      "remove_live_activity": {
+        "title": "Live Timetable",
+        "description": "Choose the Live Activities to remove.",
+        "data": {
+          "services": "Live Activities"
+        }
+      },
+      "test_live_activity": {
+        "title": "Live Timetable",
+        "description": "Choose the Live Activities to send a test notification to.",
+        "data": {
+          "services": "Live Activities"
+        }
       }
     },
     "error": {

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -342,6 +342,8 @@
     "live_activity_platform": {
       "options": {
         "ios": "iOS"
+      }
+    },
     "homework_display": {
       "options": {
         "due_date": "Due date only",

--- a/custom_components/webuntis/translations/live_activity_strings.json
+++ b/custom_components/webuntis/translations/live_activity_strings.json
@@ -1,0 +1,41 @@
+{
+  "de": {
+    "weekday": ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"],
+    "tomorrow": "morgen",
+    "on_prefix": "am",
+    "break_title": "Pause",
+    "break_next": "Als Nächstes: {lesson}",
+    "school_start_title": "Schulbeginn",
+    "school_start_begin": "Beginn um {time}",
+    "school_end_title": "Schulende",
+    "school_end_next": "Schulbeginn {day} um {time} Uhr",
+    "test_title": "Test",
+    "test_message": "Testbenachrichtigung"
+  },
+  "en": {
+    "weekday": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    "tomorrow": "tomorrow",
+    "on_prefix": "on",
+    "break_title": "Break",
+    "break_next": "Next: {lesson}",
+    "school_start_title": "School starting",
+    "school_start_begin": "Starts at {time}",
+    "school_end_title": "School's out",
+    "school_end_next": "School starts {day} at {time}",
+    "test_title": "Test",
+    "test_message": "Test notification"
+  },
+  "nl": {
+    "weekday": ["maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag", "zondag"],
+    "tomorrow": "morgen",
+    "on_prefix": "op",
+    "break_title": "Pauze",
+    "break_next": "Volgende: {lesson}",
+    "school_start_title": "School begint",
+    "school_start_begin": "Begint om {time}",
+    "school_end_title": "School is uit",
+    "school_end_next": "School begint {day} om {time}",
+    "test_title": "Test",
+    "test_message": "Testmelding"
+  }
+}

--- a/custom_components/webuntis/translations/nl.json
+++ b/custom_components/webuntis/translations/nl.json
@@ -82,7 +82,8 @@
           "calendar": "Calendar",
           "lesson": "Lesson Display",
           "backend": "Backend",
-          "notify_menu": "Notify Menu"
+          "notify_menu": "Notify Menu",
+          "live_activities_menu": "Live rooster"
         }
       },
       "filter": {
@@ -165,6 +166,21 @@
           "template": "may overwrite data keys"
         }
       },
+      "edit_live_activity": {
+        "title": "Live rooster",
+        "description": "Add or edit a Live Activity for the timetable.",
+        "data": {
+          "name": "Name",
+          "platform": "Platform",
+          "entity_id": "Notify Service",
+          "start_offset": "Start before school",
+          "end_offset": "End after school"
+        },
+        "data_description": {
+          "start_offset": "Minutes before the first lesson.",
+          "end_offset": "Minutes after the last lesson."
+        }
+      },
       "notify_menu": {
         "title": "Notify Service",
         "menu_options": {
@@ -172,6 +188,15 @@
           "edit_notify_service_select": "edit notify service",
           "remove_notify_service": "remove notify service",
           "test_notify_service": "test notify service"
+        }
+      },
+      "live_activities_menu": {
+        "title": "Live rooster",
+        "menu_options": {
+          "edit_live_activity": "add Live Timetable",
+          "edit_live_activity_select": "edit Live Timetable",
+          "remove_live_activity": "remove Live Timetable",
+          "test_live_activity": "test Live Timetable"
         }
       }
     }
@@ -202,6 +227,11 @@
         "message": "Message",
         "discord": "Discord"
       }
+    },
+    "live_activity_platform": {
+      "options": {
+        "ios": "iOS"
+      }
     }
   },
   "issues": {
@@ -224,6 +254,10 @@
         }
       },
       "title": "Password has been changed"
+    },
+    "live_activity_notify_missing": {
+      "title": "Live Timetable: notify target unreachable",
+      "description": "{entity_id} has no {service_id} action. Is the target an Companion App device? Please check the Live Timetable configuration."
     }
   },
   "services": {

--- a/docs/EXAMPLES_AND_AUTOMATIONS.md
+++ b/docs/EXAMPLES_AND_AUTOMATIONS.md
@@ -18,27 +18,14 @@ Replace `<name>` with your actual WebUntis integration device name.
 
 ## Wake-Up Alarm (Dynamic Time)
 
-```yaml
-sensor:
-  - platform: template
-    sensors:
-      webuntis_wake_time:
-        friendly_name: "WebUntis Wake-Up Time"
-        value_template: >
-          {% set datetime = states('sensor.<name>_next_lesson_to_wake_up') %}
-          {% if datetime not in ["unknown", "unavailable", None] %}
-            {{ as_datetime(datetime) - timedelta(hours=1, minutes=10) }}
-          {% else %}
-            {{ None }}
-          {% endif %}
-```
-
 Trigger automation at wake-up time:
 
 ```yaml
-trigger:
-  platform: time
-  entity_id: sensor.webuntis_wake_time
+triggers:
+  - trigger: time
+    at:
+      entity_id: sensor.<name>_next_lesson_to_wake_up
+      offset: "-0:50:0"
 action:
   # Add your wake-up actions here, e.g., switch on lights, play alarm
 ```

--- a/docs/OPTIONAL_CONFIGURATIONS.md
+++ b/docs/OPTIONAL_CONFIGURATIONS.md
@@ -48,6 +48,18 @@ Configure how lesson change notifications are sent.
 | template         | Notification template to use.                                 | `message_title` |
 | options          | Options that trigger the notification.                        | `None`          |
 
+### Live Timetable Options
+
+Show your current lessons as Live Activities directly on your Lock Screen.
+
+| Option        | Description                                                   | Default.    |
+| :------------ | :------------------------------------------------------------ | :---------- |
+| name          | Name of the Notify device.                                    | `entity_id` |
+| platform      | Device platform for this target.                              | `None`      |
+| entity_id     | Mobile App notify service, e.g., `notify.iphone_von_max`.     | `None`      |
+| start_offset  | Minutes before the first lesson to start the live activity.   | `10`        |
+| end_offset    | Minutes after the last lesson to stop the live activity.      | `10`        |
+
 ### Backend Options
 
 Control backend behavior and data generation.


### PR DESCRIPTION
Home Assistant released v2026.9.0 of their Companion App (on [iOS](https://apps.apple.com/de/app/home-assistant/id1099568401)). One of the changes is 
```
- Live Activities: follow timers and progress from Home Assistant on your Lock Screen and Dynamic Island. Special thanks to Ryan (@rwarner on GitHub) for starting this one.
```

Damit existiert endlich eine Möglichkeit, Live Activities auch auf iOS nutzen zu können. Die Android-Version hat dieses Feature schon länger. 

Um dieses Feature noch nützlicher zu machen, bekommt die WebUntis Integration jetzt die Möglichkeit, den aktuellen Stundenplan Live auf dem Lock Screen eines iPhone‘s anzeigen zu lassen.

Jetzt nur noch hoffen, das man nicht am Handy erwischt wird und es einem nicht weggenommen wird (zumindest bei mir). 

- - -
Dieses Feature nutzt teilweise den schon existierenden Notify-Service. 
„Live Stundenplan“ kann im Optionen Menü, vom WebUntis Gerät in Home Assistant konfiguriert werden:

In Home Assistant sieht das dann ungefähr so aus:

<img width="645" height="1398" alt="IMG_4555" src="https://github.com/user-attachments/assets/cb5a29c0-2dc9-4870-9ab6-84ddf7efa8f0" />

- - - 

<img width="645" height="1398" alt="IMG_4556" src="https://github.com/user-attachments/assets/08928c42-885a-49c8-99ea-16639c75c83a" />

- - - 

<img width="1290" height="2796" alt="IMG_4557" src="https://github.com/user-attachments/assets/842ae6f9-5d48-4525-89ab-fd0032e68354" />

- - - 
Test-„Live Activity“

<img width="1290" height="410" alt="IMG_4558" src="https://github.com/user-attachments/assets/3d14489b-f8ab-4c22-b3f5-aab9d313ae13" />

- - - 

> [!Note]
> Der Liquid Glass Background in Live Activities benötigt iOS 27 oder neuer. 
> iOS 27 wird Mitte-September veröffentlicht. 

Bis jetzt konnte ich es nicht 100% prüfen, da ich ein Tag nach den Entwicklungsbeginn Ferien hatte… also gerne testen und Feedback geben :)