### PR TITLE
Fix homework due date in the calendar

### DIFF
--- a/custom_components/webuntis/utils/homework.py
+++ b/custom_components/webuntis/utils/homework.py
@@ -111,12 +111,16 @@ class HomeworkEventsFetcher:
 
                 summary = get_lesson_name_str(self.server, subject, teachers[0]["name"])
 
-                # Create a calendar event for each homework entry
+                # Create a calendar event for each homework entry.
+                # Alternative to #326's span fix: place homework on its DUE
+                # date only, instead of spanning from the assigned date. HA
+                # all-day event ends are exclusive, so the event covers
+                # exactly the due date.
                 event = {
                     "uid": hw_id,
                     "summary": summary,
-                    "start": date_assigned,
-                    "end": due_date,
+                    "start": due_date,
+                    "end": due_date + timedelta(days=1),
                     "description": text,
                 }
 

--- a/custom_components/webuntis/utils/homework.py
+++ b/custom_components/webuntis/utils/homework.py
@@ -112,14 +112,10 @@ class HomeworkEventsFetcher:
                 summary = get_lesson_name_str(self.server, subject, teachers[0]["name"])
 
                 # Create a calendar event for each homework entry.
-                # Alternative to #326's span fix: place homework on its DUE
-                # date only, instead of spanning from the assigned date. HA
-                # all-day event ends are exclusive, so the event covers
-                # exactly the due date.
                 event = {
                     "uid": hw_id,
                     "summary": summary,
-                    "start": due_date,
+                    "start": date_assigned,
                     "end": due_date + timedelta(days=1),
                     "description": text,
                 }


### PR DESCRIPTION
## Summary

Alternative to the span fix proposed in #326: display each homework as a single all-day event **on its due date only**, instead of spanning from the assigned date through the due date.

**Draft / discussion proposal** — happy to rework this into a proper config-flow option once the direction is confirmed (see open questions).

## Motivation

For family and kid dashboards, a homework entry repeated on every day between `date_assigned` and `due_date` (weekends included) adds noise: the same entry fills the calendar list for days where nothing is actionable. The homework becomes relevant exactly on the day it is due — and that single day is where it should be visible.

Concrete example from our setup (subject "M", assigned Fri 2026-09-04, due Mon 2026-09-07):

```
                    Fri 04.   Sat 05.   Sun 06.   Mon 07. (due)
span fix (#326):       ✅        ✅        ✅        ✅
due-date only:         ❌        ❌        ❌        ✅
```

## Proposal

Add an **optional** setting (e.g. config-flow option `homework_display`: `span` (default) | `due_date`), so:

- existing installations keep today's behavior (no breaking change), and
- households that treat homework as "actionable on the due date" can opt in.

I'm happy to extend this draft with the full config-flow implementation once you confirm you'd accept such an option.

## Compatibility

- Only the **calendar event dict** is touched (this is exactly the boundary you described in #326: "only add the 1 day for the calendar event and not the homework object").
- The homework object itself (`parameters`: `date_assigned`, `due_date`, …) stays completely unchanged, so #254 is not affected.
- Event `uid` stays the homework id.

## Testing

- Running in production on 2 WebUntis instances (2 children), Home Assistant 2026.9.1 — homework appears exactly on its due date; descriptions remain intact on the dashboard.

## Screenshot

<img width="438" height="390" alt="image" src="https://github.com/user-attachments/assets/9cc12c98-cbb0-45df-a4b1-54357002fb3c" />

## Open questions

1. Would you accept a due-date-only display mode as an option (default stays `span`)?
2. Preferred option name and placement (config-flow options step)?
3. Or would you rather keep #326 minimal and revisit this later?
