### PR TITLE
Add option to display homework calendar events on the due date only

### DIFF
--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -234,8 +234,7 @@ class WebUntis:
         self.exclude_filter_comparison = config.options["exclude_filter_comparison"]
 
         # How homework calendar events are displayed:
-        # "span" (default) = assigned date through due date,
-        # "due_date" = due date only.
+        # "span" (default) = assigned date through due date and "due_date" = due date only.
         self.homework_display = config.options["homework_display"]
 
         self.exclude_data = config.options["exclude_data"]

--- a/custom_components/webuntis/__init__.py
+++ b/custom_components/webuntis/__init__.py
@@ -233,6 +233,11 @@ class WebUntis:
         self.filter_klassen = config.options.get("filter_klassen", [])
         self.exclude_filter_comparison = config.options["exclude_filter_comparison"]
 
+        # How homework calendar events are displayed:
+        # "span" (default) = assigned date through due date,
+        # "due_date" = due date only.
+        self.homework_display = config.options["homework_display"]
+
         self.exclude_data = config.options["exclude_data"]
         self.exclude_data_run = []
 

--- a/custom_components/webuntis/config_flow.py
+++ b/custom_components/webuntis/config_flow.py
@@ -895,6 +895,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             mode="dropdown",
                         )
                     ),
+                    vol.Required(
+                        "homework_display",
+                        default=str(
+                            self._config_entry.options.get("homework_display", "span")
+                        ),
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                "span",
+                                "due_date",
+                            ],
+                            translation_key="homework_display",
+                            mode="dropdown",
+                        )
+                    ),
                     vol.Optional(
                         "calendar_replace_name",
                         description={

--- a/custom_components/webuntis/const.py
+++ b/custom_components/webuntis/const.py
@@ -19,6 +19,7 @@ DEFAULT_OPTIONS = {
     "calendar_description": "none",
     "calendar_room": "Room long name",
     "calendar_show_room_change": False,
+    "homework_display": "span",
     "notify_config": {},
     "invalid_subjects": False,
     "exclude_filter_comparison": False,

--- a/custom_components/webuntis/const.py
+++ b/custom_components/webuntis/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "webuntis"
 
-CONFIG_ENTRY_VERSION = 22
+CONFIG_ENTRY_VERSION = 23
 
 DEFAULT_OPTIONS = {
     "lesson_long_name": True,

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -214,14 +214,16 @@
           "calendar_replace_name": "Ereignisnamen ersetzen",
           "calendar_room": "Kalender - Ort",
           "calendar_show_cancelled_lessons": "Kalender - Ausfallende Stunden",
-          "calendar_show_room_change": "Kalender - Zimmerwechsel"
+          "calendar_show_room_change": "Kalender - Zimmerwechsel",
+          "homework_display": "Hausaufgaben - Anzeigemodus"
         },
         "data_description": {
           "calendar_description": "Bestimme, was in der Beschreibung eines Kalender-Events stehen soll.",
           "calendar_replace_name": "Bsp:\nCancelled: ❌",
           "calendar_room": "Bestimme, was im Kalender als Ort angezeigt wird.",
           "calendar_show_cancelled_lessons": "Zeige ausfallende Stunden im Kalender an.",
-          "calendar_show_room_change": "Zeige Zimmerwechsel im Kalender an."
+          "calendar_show_room_change": "Zeige Zimmerwechsel im Kalender an.",
+          "homework_display": "Wähle, wie Hausaufgaben im Hausaufgaben-Kalender erscheinen: als Spanne vom Erteilungs- bis zum Fälligkeitstag (Standard) oder nur am Fälligkeitstag."
         },
         "description": "Einstellungen zur Kalender Darstellung.",
         "title": "Kalender-Einstellungen"
@@ -306,6 +308,12 @@
         "json": "JSON",
         "lesson_info": "Stunden Info",
         "none": "Keine"
+      }
+    },
+    "homework_display": {
+      "options": {
+        "due_date": "Nur am Fälligkeitstag",
+        "span": "Spanne (Erteilung bis Fälligkeit)"
       }
     },
     "notify_options": {

--- a/custom_components/webuntis/translations/de.json
+++ b/custom_components/webuntis/translations/de.json
@@ -214,7 +214,7 @@
           "calendar_replace_name": "Ereignisnamen ersetzen",
           "calendar_room": "Kalender - Ort",
           "calendar_show_cancelled_lessons": "Kalender - Ausfallende Stunden",
-          "calendar_show_room_change": "Kalender - Zimmerwechsel",
+          "calendar_show_room_change": "Kalender - Raumwechsel",
           "homework_display": "Hausaufgaben - Anzeigemodus"
         },
         "data_description": {
@@ -222,8 +222,8 @@
           "calendar_replace_name": "Bsp:\nCancelled: ❌",
           "calendar_room": "Bestimme, was im Kalender als Ort angezeigt wird.",
           "calendar_show_cancelled_lessons": "Zeige ausfallende Stunden im Kalender an.",
-          "calendar_show_room_change": "Zeige Zimmerwechsel im Kalender an.",
-          "homework_display": "Wähle, wie Hausaufgaben im Hausaufgaben-Kalender erscheinen: als Spanne vom Erteilungs- bis zum Fälligkeitstag (Standard) oder nur am Fälligkeitstag."
+          "calendar_show_room_change": "Zeige Raumwechsel im Kalender an.",
+          "homework_display": "Wähle, wie Hausaufgaben im Hausaufgaben-Kalender erscheinen: als Zeitspanne vom Erteilungs- bis zum Fälligkeitstag (Standard) oder nur am Fälligkeitstag."
         },
         "description": "Einstellungen zur Kalender Darstellung.",
         "title": "Kalender-Einstellungen"
@@ -313,7 +313,7 @@
     "homework_display": {
       "options": {
         "due_date": "Nur am Fälligkeitstag",
-        "span": "Spanne (Erteilung bis Fälligkeit)"
+        "span": "Zeitspanne (Erteilung bis Fälligkeit)"
       }
     },
     "notify_options": {

--- a/custom_components/webuntis/translations/en.json
+++ b/custom_components/webuntis/translations/en.json
@@ -214,14 +214,16 @@
           "calendar_replace_name": "Replace event name",
           "calendar_room": "Calendar - Location",
           "calendar_show_cancelled_lessons": "Calendar - cancelled lessons",
-          "calendar_show_room_change": "Calendar - Room change"
+          "calendar_show_room_change": "Calendar - Room change",
+          "homework_display": "Homework - display mode"
         },
         "data_description": {
           "calendar_description": "Determine what should be in the description of a calendar event.",
           "calendar_replace_name": "e.g.,\nCancelled: ❌",
           "calendar_room": "Specify what to display for location.",
           "calendar_show_cancelled_lessons": "Show cancelled lessons in the calendar.",
-          "calendar_show_room_change": "Show room changes in the calendar."
+          "calendar_show_room_change": "Show room changes in the calendar.",
+          "homework_display": "Choose how homework events appear in the homework calendar: spanning the assigned date through the due date (default), or on the due date only."
         },
         "description": "Settings to customize the calendar.",
         "title": "Calendar Settings"
@@ -306,6 +308,12 @@
         "json": "JSON",
         "lesson_info": "Lesson Info",
         "none": "None"
+      }
+    },
+    "homework_display": {
+      "options": {
+        "due_date": "Due date only",
+        "span": "Span (assigned date through due date)"
       }
     },
     "notify_options": {

--- a/custom_components/webuntis/utils/homework.py
+++ b/custom_components/webuntis/utils/homework.py
@@ -112,16 +112,9 @@ class HomeworkEventsFetcher:
                 summary = get_lesson_name_str(self.server, subject, teachers[0]["name"])
 
                 # Create a calendar event for each homework entry.
-                # Display mode (config option "homework_display"):
-                # - "span" (default): event spans the assigned date through
-                #   the due date.
-                # - "due_date": event is shown on the due date only.
-                # HA all-day event ends are exclusive (RFC 5545), so the end
-                # is always due_date + 1 day to cover the due date itself.
                 event_start = (
                     due_date
-                    if getattr(self.server, "homework_display", "span")
-                    == "due_date"
+                    if getattr(self.server, "homework_display", "span") == "due_date"
                     else date_assigned
                 )
                 event = {

--- a/custom_components/webuntis/utils/homework.py
+++ b/custom_components/webuntis/utils/homework.py
@@ -112,10 +112,22 @@ class HomeworkEventsFetcher:
                 summary = get_lesson_name_str(self.server, subject, teachers[0]["name"])
 
                 # Create a calendar event for each homework entry.
+                # Display mode (config option "homework_display"):
+                # - "span" (default): event spans the assigned date through
+                #   the due date.
+                # - "due_date": event is shown on the due date only.
+                # HA all-day event ends are exclusive (RFC 5545), so the end
+                # is always due_date + 1 day to cover the due date itself.
+                event_start = (
+                    due_date
+                    if getattr(self.server, "homework_display", "span")
+                    == "due_date"
+                    else date_assigned
+                )
                 event = {
                     "uid": hw_id,
                     "summary": summary,
-                    "start": date_assigned,
+                    "start": event_start,
                     "end": due_date + timedelta(days=1),
                     "description": text,
                 }


### PR DESCRIPTION
## Summary

Follow-up to the #329 discussion (as requested there, the feature now comes as its **own PR**, separate from the merged +1-day fix for #326):

Adds an **optional** config-flow setting **"Homework - display mode"** (`homework_display`, Calendar settings) with two values:

| Mode | Calendar behavior |
|---|---|
| `span` *(default)* | Homework spans the assigned date through the due date — **unchanged behavior** for existing installations |
| `due_date` | Homework appears as a single all-day event **exactly on its due date** |

## Motivation

For family / kid dashboards a homework entry repeated on every day between `date_assigned` and `due_date` (weekends included) is noise: the entry is only actionable on the day it is due. Concrete example (subject "M", assigned Fri 2026-09-04, due Mon 2026-09-07):

```
                    Fri 04.   Sat 05.   Sun 06.   Mon 07. (due)
span (default):        ✅        ✅        ✅        ✅
due_date:              ❌        ❌        ❌        ✅
```

## Implementation notes

- The calendar event end stays `due_date + timedelta(days=1)` in **both** modes (all-day event ends are exclusive per RFC 5545, keeping the #326 fix intact) — only the event `start` differs.
- The homework object itself (`parameters`: `date_assigned`, `due_date`, …) is **never modified** — same boundary as agreed in #329, so **#254 is not affected**.
- `"homework_display": "span"` added to `DEFAULT_OPTIONS` → existing config entries pick the default up through the entry migration; no breaking change.
- Translations added for `en` and `de` (`nl` has no `options` section in this repo, so it falls back to English).

## Testing

- `py_compile` clean; JSON translations validated.
- Running the equivalent change in production on 2 WebUntis instances (2 children), Home Assistant 2026.9.1 — homework appears exactly on its due date; descriptions render on the dashboard (Calendar Card Pro `show_description`).

Happy to adjust the option key name, placement (e.g. its own "Homework" settings group) or the German wording.
