### PR TITLE
Bugfix/teacher fallback list

### DIFF
--- a/custom_components/webuntis/utils/web_untis_extended.py
+++ b/custom_components/webuntis/utils/web_untis_extended.py
@@ -243,7 +243,15 @@ class ExtendedSession(WebUntisSession):
         ):  # only do this when we haven't already determined that fetching teachers is forbidden, otherwise we would do unnecessary requests to the server
             try:
                 result = super().teachers(**kw_args)
-                self.teachers_forbidden = False
+                if not result:
+                    log(
+                        "debug",
+                        "Fetching teachers returned an empty result. Assuming fetching teachers is forbidden and using fallback mechanism.",
+                    )
+                    self.teachers_forbidden = True
+                    result = None
+                else:
+                    self.teachers_forbidden = False
             except Exception as e:
                 if getattr(
                     e, "code", None


### PR DESCRIPTION
several improvements to the teacher mapping logic,
  * prevent misleading log message when teacher rights are missing by filtering the log messages temporarily (issue #323)
  * assume rights are missing when teacher list is empty to enable workaround (issue #324)
  * corrected start and end date of teacher fallback to be working between school years